### PR TITLE
chore: narrow cloud-scheduler trigger to 8 essential slots

### DIFF
--- a/.claude/skills/cloud-scheduler/SKILL.md
+++ b/.claude/skills/cloud-scheduler/SKILL.md
@@ -30,23 +30,19 @@ Parse the output into `<hour>` (integer) and `<day_of_week>` (integer).
 
 Match the current hour and day against the dispatch table below. Invoke each skill **sequentially** using the `Skill` tool.
 
-x-post-cloud runs **every hour** as the first skill. All other skills keep their existing schedule:
+The trigger fires 8 times per day at JST 0/6/10/12/15/18/19/21 (HH:23). x-post-cloud runs first at every slot; other skills run at their designated slots.
 
 | Hour | Day     | Skills (invoke in this order)                                                                     |
 |------|---------|---------------------------------------------------------------------------------------------------|
 | 0    | Daily   | x-post-cloud → nutrition-check-cloud                                                              |
-| 1-5  | Daily   | x-post-cloud                                                                                      |
 | 6    | Daily   | x-post-cloud → nutrition-check-cloud                                                              |
-| 7-9  | Daily   | x-post-cloud                                                                                      |
 | 10   | Sun (7) | x-post-cloud → weekly-plan-cloud → daily-plan-cloud → x-draft-cloud → nutrition-check-cloud       |
 | 10   | 1-6     | x-post-cloud → daily-plan-cloud → x-draft-cloud → nutrition-check-cloud                           |
-| 11-14| Daily   | x-post-cloud                                                                                      |
+| 12   | Daily   | x-post-cloud                                                                                      |
 | 15   | Daily   | x-post-cloud → nutrition-check-cloud                                                              |
-| 16-17| Daily   | x-post-cloud                                                                                      |
-| 18   | Daily   | x-post-cloud → x-draft-cloud                                                                     |
-| 19-20| Daily   | x-post-cloud                                                                                      |
+| 18   | Daily   | x-post-cloud → x-draft-cloud                                                                      |
+| 19   | Daily   | x-post-cloud                                                                                      |
 | 21   | Daily   | x-post-cloud → nutrition-check-cloud                                                              |
-| 22-23| Daily   | x-post-cloud                                                                                      |
 
 For each skill in the matched row:
 1. Invoke it using the `Skill` tool with the skill name (e.g., `x-post-cloud`)


### PR DESCRIPTION
## Summary

- Reduce cloud-scheduler firings from 24/day (hourly) to 8/day to stay within the 15/day free quota.
- Drop the "x post at any hour" flexibility — approved drafts are now picked up at the next of 8 fixed slots.
- Offset cron minute to `:23` to avoid HH:00 traffic spikes (and the more common `:07` offset).

## Schedule

| JST | UTC | Skills |
|---|---|---|
| 00:23 | 15:23 (prev) | x-post + nutrition (final) |
| 06:23 | 21:23 (prev) | x-post + nutrition (morning) |
| 10:23 | 01:23 | x-post + daily-plan + x-draft + nutrition (+ weekly-plan on Sun) |
| 12:23 | 03:23 | x-post (`default_post_times[0]`) |
| 15:23 | 06:23 | x-post + nutrition (lunch) |
| 18:23 | 09:23 | x-post + x-draft |
| 19:23 | 10:23 | x-post (`default_post_times[1]`) |
| 21:23 | 12:23 | x-post + nutrition (dinner) |

Cron: `7 * * * *` → `23 1,3,6,9,10,12,15,21 * * *`

## Notes

- `alt.toml` `default_post_times = ["12:00", "19:00"]` already aligns with the new 12/19 slots — no change needed.
- Approved drafts with `scheduled_at` not aligned to a slot will be posted at the next slot after their target time (e.g., 13:30 → 15:23).
- `wake-check-cloud` remains out of scope (needs sub-hour escalation, separate trigger).
- Trigger `trig_01NzQ7diQT9GGJCiLFs7AC4u` cron has been updated separately via the schedule API.

## Test plan

- [ ] Confirm trigger next-run shows the new schedule on https://claude.ai/code/scheduled
- [ ] Verify x-post-cloud picks up approved drafts at the next slot
- [ ] Verify nutrition/daily-plan/x-draft/weekly-plan still fire at their expected hours

## Follow-up

- Make trigger times configurable (`alt.toml` based) — currently hard-coded in dispatch table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)