### PR TITLE
feat(discord): split daily plan into channel summary + thread detail

### DIFF
--- a/.claude/skills/daily-plan-cloud/SKILL.md
+++ b/.claude/skills/daily-plan-cloud/SKILL.md
@@ -76,16 +76,36 @@ Run these in parallel:
 
 ### Phase 3: Plan Generation
 
-Generate a daily plan autonomously using the collected data. Use this output format:
+Generate a daily plan autonomously using the collected data.
+
+**Summary (for channel message):**
+
+```
+📋 <YYYY-MM-DD> (<Day>) Daily Plan
+
+🔧 repo#123: issue title
+🔧 repo#456: issue title
+📅 Notable calendar event HH:MM
+✅ Routine item
+```
+
+- **🔧** P0/P1 issues (auto-selected by priority)
+- **📅** Calendar events requiring preparation or action
+- **✅** Overdue and today-due routines
+- One item per line, icon repeated per item
+- Omit categories with no items
+- Blank line between title and items
+
+**Full plan (for thread):**
 
 ```
 ## Today's Schedule (YYYY-MM-DD Day)
 - HH:MM-HH:MM [Calendar] Event name
 - ...
 
-## Development Tasks (GitHub)
-Group issues by priority label (P1 first, then P2). Issues without priority labels are listed separately.
-- repo#123: Issue title [label1, label2]
+## Recommended Issues
+Select up to 5 recommended issues based on priority (P0/P1 first), milestone urgency, and recent activity. Do not list all open issues — the weekly plan covers that.
+- repo#123: Issue title [P1]
 - ...
 
 ## Routines Due
@@ -110,21 +130,25 @@ Prioritization logic (autonomous, no user input):
 
 ### Phase 4: Save and Post
 
-Post the plan to Discord with threading:
+**Post summary to channel:**
 ```bash
-uv run alt-discord post-thread <daily_channel_id> "📋 <YYYY-MM-DD> (<Day>) Daily Plan" "<plan_text>"
+uv run alt-discord post "<daily_channel_id>" "<summary_text>"
+```
+Parse the JSON output to extract `message_ids[0]` as `<summary_message_id>`.
+
+**Post full plan to thread:**
+```bash
+uv run alt-discord post-thread "<daily_channel_id>" "📋 <YYYY-MM-DD> (<Day>) Daily Plan" "<full_plan_text>" --message-id <summary_message_id>
 ```
 Parse the JSON output to extract `thread_id`.
 
-Save the plan to the entries table (include thread_id in metadata):
+**Save to DB:**
 ```bash
 uv run alt-db entry add --type daily_plan --status posted \
   --title "Daily Plan <YYYY-MM-DD>" \
-  --content "<plan_text>" \
+  --content "<summary_text>\n\n---\n\n<full_plan_text>" \
   --metadata '{"source": "cloud", "thread_id": "<thread_id>"}'
 ```
-
-The `post-thread` command handles the 2000 character limit automatically — the first chunk is posted to the channel, a thread is created on it, and any remaining chunks are posted inside the thread.
 
 ### Environment Variables (set in Cloud environment)
 

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -53,9 +53,9 @@ Present all gathered information organized as:
 - HH:MM-HH:MM [Calendar] Event name
 - ...
 
-## Development Tasks (GitHub)
-Group issues by priority label (P1 first, then P2). Issues without priority labels are listed separately.
-- repo#123: Issue title [label1, label2]
+## Recommended Issues (GitHub)
+Select up to 5 recommended issues based on priority (P0/P1 first), milestone urgency, and recent activity. Do not list all open issues — the weekly plan covers that.
+- repo#123: Issue title [P1]
 - ...
 
 ## Routines Due
@@ -86,20 +86,61 @@ Discuss with the user:
 
 After the planning discussion is complete, **always** post the finalized plan to Discord. Do not ask — just post it.
 
-Post the plan with threading:
-```bash
-uv run alt-discord post-thread <daily_channel_id> "📋 <YYYY-MM-DD> (<Day>) Daily Plan" "<plan_text>"
+Read daily channel: `uv run alt-db config get plan.discord.channel_id`.
+
+**Step 1: Generate the summary**
+
+Based on the Phase 3 discussion outcome, generate a concise channel summary:
+
 ```
-Read daily channel: `uv run alt-db config get plan.discord.channel_id`. Parse the JSON output to extract `thread_id`.
+📋 <YYYY-MM-DD> (<Day>) Daily Plan
 
-The posted plan should be a concise summary reflecting the discussion outcome (revised schedule, priorities, notes), not the raw Phase 2 output.
+🔧 repo#123: issue title
+🔧 repo#456: issue title
+📅 Notable calendar event HH:MM
+✅ Routine item
+```
 
-The `post-thread` command handles the 2000 character limit automatically — the first chunk is posted to the channel, a thread is created on it, and any remaining chunks are posted inside the thread.
+- **🔧** Issues decided to work on today
+- **📅** Calendar events requiring action or attention
+- **✅** Routines to handle today
+- One item per line, icon repeated per item
+- Omit categories with no items
+- Blank line between title and items
 
-After posting to Discord, save the plan to the entries table for Cloud skip detection:
+**Step 2: Generate the full plan**
+
+The full plan reflects the discussion outcome (revised schedule, priorities, notes). Use these sections:
+
+- **Today's Schedule** — full calendar event list
+- **Recommended Issues** — curated issue candidates with priority labels
+- **Routines Due** — overdue and upcoming
+- **Goals & Reminders** — active goals, approaching deadlines, memos
+- **Rest of Week Overview** — upcoming events and deadlines
+
+**Step 3: Post summary to channel**
+
+```bash
+uv run alt-discord post "<daily_channel_id>" "<summary_text>"
+```
+
+Parse the JSON output to extract `message_ids[0]` as `<summary_message_id>`.
+
+**Step 4: Post full plan to thread**
+
+```bash
+uv run alt-discord post-thread "<daily_channel_id>" "📋 <YYYY-MM-DD> (<Day>) Daily Plan" "<full_plan_text>" --message-id <summary_message_id>
+```
+
+Parse the JSON output to extract `thread_id`.
+
+**Step 5: Save to DB**
+
+Combine summary and full plan for storage:
+
 ```bash
 uv run alt-db entry add --type daily_plan --status posted \
   --title "Daily Plan <YYYY-MM-DD>" \
-  --content "<plan_text>" \
+  --content "<summary_text>\n\n---\n\n<full_plan_text>" \
   --metadata '{"source": "local", "thread_id": "<thread_id>"}'
 ```

--- a/src/alt_discord/cli.py
+++ b/src/alt_discord/cli.py
@@ -6,7 +6,7 @@ import json
 from dotenv import load_dotenv
 
 from .reader import fetch_messages, format_messages
-from .poster import post_message
+from .poster import post_message, split_message, create_thread_from_message
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -29,6 +29,7 @@ def build_parser() -> argparse.ArgumentParser:
     pt_parser.add_argument("channel_id")
     pt_parser.add_argument("thread_name")
     pt_parser.add_argument("message")
+    pt_parser.add_argument("--message-id", default=None, help="Existing message ID to create thread on (skip channel post)")
 
     return parser
 
@@ -49,25 +50,36 @@ def main():
         print(json.dumps({"message_ids": message_ids, "chunks": len(message_ids)}))
 
     elif args.command == "post-thread":
-        from .poster import split_message, create_thread_from_message
-
-        chunks = split_message(args.message)
-        # Post first chunk to the channel
-        first_ids = post_message(args.channel_id, chunks[0])
-        first_message_id = first_ids[0]
-        # Create thread on that message
-        thread = create_thread_from_message(
-            args.channel_id, first_message_id, args.thread_name
-        )
-        thread_id = thread["id"]
-        # Post remaining chunks inside the thread
-        for chunk in chunks[1:]:
-            post_message(thread_id, chunk)
-        print(json.dumps({
-            "message_id": first_message_id,
-            "thread_id": thread_id,
-            "chunks": len(chunks),
-        }))
+        if args.message_id:
+            # Create thread on an existing message, post body into the thread
+            thread = create_thread_from_message(
+                args.channel_id, args.message_id, args.thread_name
+            )
+            thread_id = thread["id"]
+            chunks = split_message(args.message)
+            for chunk in chunks:
+                post_message(thread_id, chunk)
+            print(json.dumps({
+                "message_id": args.message_id,
+                "thread_id": thread_id,
+                "chunks": len(chunks),
+            }))
+        else:
+            # Original behavior: post first chunk to channel, create thread, post rest
+            chunks = split_message(args.message)
+            first_ids = post_message(args.channel_id, chunks[0])
+            first_message_id = first_ids[0]
+            thread = create_thread_from_message(
+                args.channel_id, first_message_id, args.thread_name
+            )
+            thread_id = thread["id"]
+            for chunk in chunks[1:]:
+                post_message(thread_id, chunk)
+            print(json.dumps({
+                "message_id": first_message_id,
+                "thread_id": thread_id,
+                "chunks": len(chunks),
+            }))
 
 
 if __name__ == "__main__":

--- a/tests/test_discord_cli.py
+++ b/tests/test_discord_cli.py
@@ -1,5 +1,8 @@
 """Tests for Discord CLI argument parsing."""
 
+import json
+from unittest.mock import patch
+
 from alt_discord.cli import build_parser
 
 
@@ -37,3 +40,56 @@ def test_post_thread_command():
     assert args.channel_id == "123456789"
     assert args.thread_name == "📋 2026-04-12 (Sat) Daily Plan"
     assert args.message == "Hello world"
+
+
+def test_post_thread_command_with_message_id():
+    parser = build_parser()
+    args = parser.parse_args([
+        "post-thread", "123456789",
+        "📋 2026-04-15 (Tue) Daily Plan",
+        "Full plan content here",
+        "--message-id", "msg-999",
+    ])
+    assert args.command == "post-thread"
+    assert args.channel_id == "123456789"
+    assert args.thread_name == "📋 2026-04-15 (Tue) Daily Plan"
+    assert args.message == "Full plan content here"
+    assert args.message_id == "msg-999"
+
+
+def test_post_thread_command_without_message_id():
+    parser = build_parser()
+    args = parser.parse_args([
+        "post-thread", "123456789",
+        "📋 2026-04-15 (Tue) Daily Plan",
+        "Hello world",
+    ])
+    assert args.message_id is None
+
+
+@patch("alt_discord.cli.post_message")
+@patch("alt_discord.cli.create_thread_from_message")
+@patch.dict("os.environ", {"DISCORD_BOT_TOKEN": "test-token"})
+def test_post_thread_with_message_id_skips_channel_post(mock_create_thread, mock_post_message):
+    """When --message-id is given, skip channel post and create thread on that message."""
+    mock_create_thread.return_value = {"id": "thread-100", "name": "Test Thread"}
+    mock_post_message.return_value = ["msg-body-1"]
+
+    from alt_discord.cli import main
+    with patch("sys.argv", [
+        "alt-discord", "post-thread", "ch-123",
+        "📋 2026-04-15 (Tue) Daily Plan",
+        "Full plan body",
+        "--message-id", "msg-999",
+    ]):
+        with patch("builtins.print") as mock_print:
+            main()
+
+    # Thread created on the provided message, NOT a new channel post
+    mock_create_thread.assert_called_once_with("ch-123", "msg-999", "📋 2026-04-15 (Tue) Daily Plan")
+    # Body posted into the thread
+    mock_post_message.assert_called_once_with("thread-100", "Full plan body")
+    # Output includes the provided message_id
+    output = json.loads(mock_print.call_args[0][0])
+    assert output["message_id"] == "msg-999"
+    assert output["thread_id"] == "thread-100"


### PR DESCRIPTION
## Summary
- Add `--message-id` option to `post-thread` CLI to create threads on existing messages
- Update daily-plan and daily-plan-cloud skills to post concise summary to channel (date + action items with category icons) and full plan details in thread
- Rename "Development Tasks" to "Recommended Issues" with curated selection (up to 5, priority-based)

## Test plan
- [x] All 7 Discord CLI tests pass (4 existing + 3 new)
- [x] Run `/daily-plan` and verify channel shows concise summary, thread has full plan
- [ ] Verify cloud scheduled daily plan produces same format

🤖 Generated with [Claude Code](https://claude.com/claude-code)