### PR TITLE
feat: personal task management via entries table

### DIFF
--- a/.claude/rules/database-entries.md
+++ b/.claude/rules/database-entries.md
@@ -1,29 +1,201 @@
 # Database Entries Management
 
-## Entry Types
+## Entry Types Overview
 
-Use `uv run alt-db entry` to manage entries in Neon Postgres (the second brain store).
+Use `uv run alt-db entry` to manage entries in Neon Postgres (the second brain store). All persistent data is stored as rows in the `entries` table with a `type` field that determines schema conventions.
 
-| Type | Purpose | Example |
-|---|---|---|
-| `knowledge` | Decisions, standards, reference info to persist | Tech stack choices, design principles |
-| `goal` | Trackable objectives with target dates | "Launch app by 2026-09" |
-| `memo` | Temporary notes, ideas, observations | Meeting notes, quick ideas |
-| `tech_interest` | Technologies to explore or evaluate | "Look into Deno 2.0" |
-| `business` | Business-related decisions and plans | Revenue targets, strategy |
-
-## Type Mapping
-
-These entry types replaced dedicated tables in the old schema:
-
-| Old Table | Entry Type |
+| Type | Purpose |
 |---|---|
-| routine_events | `routine_event` |
-| body_measurements | `body_measurement` |
-| body_measurement_goals | `body_measurement_goal` |
-| nutrition_items | `nutrition_item` |
-| nutrition_logs | `nutrition_log` |
-| nutrition_targets | `nutrition_target` |
+| `task` | One-off action items with optional priority and due date |
+| `knowledge` | Decisions, standards, reference info to persist |
+| `goal` | Trackable objectives with target dates |
+| `memo` | Temporary notes, ideas, observations |
+| `tech_interest` | Technologies to explore or evaluate |
+| `business` | Business-related decisions and plans |
+| `routine_event` | Routine completion / baseline records |
+| `body_measurement` | Body composition snapshots (e.g., InBody) |
+| `body_measurement_goal` | Body composition target settings |
+| `nutrition_item` | Food items registry (calorie/protein per item) |
+| `nutrition_log` | Daily food intake records |
+| `nutrition_target` | Daily calorie/protein targets |
+| `nutrition_thread` | Discord thread tracking for daily nutrition logging |
+| `daily_plan` | Posted daily plan archive |
+| `weekly_plan` | Posted weekly plan archive |
+| `x_draft` | X (Twitter) post drafts awaiting approval |
+| `wake_event` | Wake-up nudge attempts |
+
+## Per-Type Reference
+
+Each section follows the same shape:
+- Status: allowed values (with default if any)
+- Metadata: schema for the JSON metadata column
+- Content: how the content column is used
+- Parent: how parent_id is used
+- Lifecycle: how entries of this type come into being and transition
+- Consumers: skills/UI that read this type
+
+### task
+
+- Status: active(default) / backlog / done / cancelled
+- Metadata: { priority: "P0|P1|P2|P3" (optional), due_date: "YYYY-MM-DD" (optional) }
+- Content: free-form notes (optional)
+- Parent: optional — references parent task entry id for sub-tasks; parent and child statuses are independent
+- Lifecycle: Discord memo → daily-plan/weekly-plan promotion → active or backlog → done or cancelled
+- Consumers: daily-plan (active list + notable elevation to summary), weekly-plan (active list + backlog review), webapp `/entries`
+
+### knowledge
+
+- Status: not used
+- Metadata: not used
+- Content: full body of the knowledge entry (decisions, standards, design principles)
+- Parent: not used
+- Lifecycle: created manually when a decision should persist for future reference
+- Consumers: weekly-plan (recent entries review), webapp `/entries`
+
+### goal
+
+- Status: active / backlog / achieved
+- Metadata: { target_date: "YYYY-MM" }
+- Content: goal description
+- Parent: not used
+- Lifecycle: created manually; reviewed in weekly-plan; transitions to achieved when met
+- Consumers: daily-plan (active goals, due-soon flag), weekly-plan (active + stale review), webapp `/entries`
+
+### memo
+
+- Status: not used
+- Metadata: not used
+- Content: free-form text
+- Parent: not used
+- Lifecycle: quick capture for ideas or observations; reviewed during weekly-plan or routinely promoted into other types if they prove worth tracking
+- Consumers: daily-plan (recent memos), weekly-plan (recent memos), webapp `/entries`
+
+### tech_interest
+
+- Status: not used (typically)
+- Metadata: not used (typically)
+- Content: technology name + brief context
+- Parent: not used
+- Lifecycle: captured when a technology to explore comes up; reviewed periodically
+- Consumers: webapp `/entries`
+
+### business
+
+- Status: not used (typically)
+- Metadata: not used (typically)
+- Content: business decision, plan, or note
+- Parent: not used
+- Lifecycle: captured when a business-related decision should persist
+- Consumers: webapp `/entries`
+
+### routine_event
+
+- Status: completed / baseline
+- Metadata: { category: string, completed_at: "ISO8601 with offset" }
+- Content: optional note about the completion (e.g., next appointment date)
+- Parent: not used
+- Lifecycle: created when a routine is performed (`completed`) or when establishing a starting point for a new routine (`baseline`)
+- Consumers: routines skill (overdue/due-soon calculation), daily-plan (overdue routines), weekly-plan (week's routines)
+
+### body_measurement
+
+- Status: not used (time-series data)
+- Metadata: { measured_at, weight_kg, skeletal_muscle_mass_kg, muscle_mass_kg, body_fat_mass_kg, body_fat_percent, bmi, basal_metabolic_rate, inbody_score, waist_hip_ratio, visceral_fat_level, ffmi, skeletal_muscle_ratio }
+- Content: not used
+- Parent: not used
+- Title: `InBody YYYY-MM-DD`
+- Lifecycle: imported from InBody export via `alt-body` CLI; deduplicated by `metadata.measured_at`
+- Consumers: webapp `/body` page (charts and history)
+
+### body_measurement_goal
+
+- Status: active / achieved
+- Metadata: { metric: string, target_value: number, start_value: number|null, start_date: "YYYY-MM-DD", target_date: "YYYY-MM-DD" }
+- Content: not used
+- Parent: not used
+- Title: metric name (e.g., `weight_kg`)
+- Lifecycle: created via webapp body goal UI; status flips to achieved when target met
+- Consumers: webapp `/body` page
+
+### nutrition_item
+
+- Status: not used
+- Metadata: { calories_kcal: number, protein_g: number, source: "user_registered" | … }
+- Content: not used
+- Parent: not used
+- Title: food/item name
+- Lifecycle: registered via Discord meal-log workflow when a recurring food item is identified
+- Consumers: nutrition-check-cloud skill (lookup table for known foods)
+
+### nutrition_log
+
+- Status: not used
+- Metadata: { logged_date: "YYYY-MM-DD", meal_type: "breakfast|lunch|dinner|snack|supplement", calories_kcal: number, protein_g: number, source_message_id: string, estimated_by: "registered" | "llm" }
+- Content: not used (sometimes notes)
+- Parent: not used
+- Title: food description as logged
+- Lifecycle: created by nutrition-check-cloud skill from Discord meal thread messages
+- Consumers: nutrition-check-cloud skill (daily totals), future nutrition dashboard
+
+### nutrition_target
+
+- Status: active
+- Metadata: { calories_kcal: number, protein_g: number }
+- Content: not used
+- Parent: not used
+- Title: target descriptor (e.g., `daily`)
+- Lifecycle: created/updated via CLI when targets change; only one active at a time
+- Consumers: nutrition-check-cloud skill (target comparison)
+
+### nutrition_thread
+
+- Status: not used
+- Metadata: { date: "YYYY-MM-DD", thread_id: string }
+- Content: thread_id (also stored in metadata)
+- Parent: not used
+- Title: `Nutrition Thread <date>`
+- Lifecycle: created by nutrition-check-cloud when a daily meal thread is opened in Discord
+- Consumers: nutrition-check-cloud skill (locating today's thread)
+
+### daily_plan
+
+- Status: posted
+- Metadata: { source: "local" | "cloud", thread_id: string }
+- Content: full plan text (summary + thread detail combined with `---` separator)
+- Parent: not used
+- Title: `Daily Plan YYYY-MM-DD`
+- Lifecycle: created at the end of daily-plan or daily-plan-cloud after Discord posting
+- Consumers: daily-plan-cloud (idempotency check), wake-check-cloud (presence check), weekly-plan (week's history)
+
+### weekly_plan
+
+- Status: posted
+- Metadata: not used
+- Content: full plan text
+- Parent: not used
+- Title: `Weekly Plan <monday YYYY-MM-DD>`
+- Lifecycle: created at the end of weekly-plan or weekly-plan-cloud after Discord posting
+- Consumers: weekly-plan-cloud (idempotency check)
+
+### x_draft
+
+- Status: draft / approved (and any other lifecycle values used by x-draft-cloud)
+- Metadata: { source_commits, source_memo_count, source_design_doc, source_pr_url, generated_at, image_url, post_type: "progress|technical|problem-solution|reflection", hashtags, reply_link, reply_link_label, project }
+- Content: draft post text
+- Parent: not used
+- Title: one-line summary
+- Lifecycle: created by x-draft-cloud from recent activity; reviewed in webapp `/posts`; status flips to `approved` upon human review; consumed by x-post-cloud when posting
+- Consumers: webapp `/posts` (review/approve), x-post-cloud (post when due)
+
+### wake_event
+
+- Status: sent
+- Metadata: { attempt: number, scenario: "morning" | "night", target_time: "HH:MM" }
+- Content: message text sent
+- Parent: not used
+- Title: `Wake: <scenario> attempt <N>`
+- Lifecycle: created by wake-check-cloud each time a nudge is sent; idempotency tracking
+- Consumers: wake-check-cloud (escalation logic, idempotency)
 
 ## CLI Commands
 
@@ -51,6 +223,7 @@ uv run alt-db entry delete <id>
 Save an entry when information is:
 - A **decision** that should inform future work (tech stack, conventions, policies)
 - A **goal or objective** with a clear outcome
+- A **task** to act on (one-off, optionally with priority and due date)
 - A **note or idea** worth revisiting later
 - **Not derivable** from code, git history, or existing docs
 

--- a/.claude/rules/database-entries.md
+++ b/.claude/rules/database-entries.md
@@ -31,6 +31,7 @@ Each section follows the same shape:
 - Metadata: schema for the JSON metadata column
 - Content: how the content column is used
 - Parent: how parent_id is used
+- Title: format convention (include only when the title format is load-bearing — e.g., used as a query key, a routine name match, or a date-encoded identifier)
 - Lifecycle: how entries of this type come into being and transition
 - Consumers: skills/UI that read this type
 
@@ -94,6 +95,7 @@ Each section follows the same shape:
 - Metadata: { category: string, completed_at: "ISO8601 with offset" }
 - Content: optional note about the completion (e.g., next appointment date)
 - Parent: not used
+- Title: routine name; must match a key in `config.routines` (the routines skill matches completion records to definitions by title)
 - Lifecycle: created when a routine is performed (`completed`) or when establishing a starting point for a new routine (`baseline`)
 - Consumers: routines skill (overdue/due-soon calculation), daily-plan (overdue routines), weekly-plan (week's routines)
 
@@ -130,7 +132,7 @@ Each section follows the same shape:
 ### nutrition_log
 
 - Status: not used
-- Metadata: { logged_date: "YYYY-MM-DD", meal_type: "breakfast|lunch|dinner|snack|supplement", calories_kcal: number, protein_g: number, source_message_id: string, estimated_by: "registered" | "llm" }
+- Metadata: { logged_date: "YYYY-MM-DD", meal_type: "breakfast|lunch|dinner|snack|supplement", calories_kcal: number, protein_g: number, source_message_id: string, estimated_by: "item_lookup" | "label_read" | "web_lookup" | "llm" }
 - Content: not used (sometimes notes)
 - Parent: not used
 - Title: food description as logged
@@ -179,7 +181,7 @@ Each section follows the same shape:
 
 ### x_draft
 
-- Status: draft / approved (and any other lifecycle values used by x-draft-cloud)
+- Status: draft / approved / posted
 - Metadata: { source_commits, source_memo_count, source_design_doc, source_pr_url, generated_at, image_url, post_type: "progress|technical|problem-solution|reflection", hashtags, reply_link, reply_link_label, project }
 - Content: draft post text
 - Parent: not used

--- a/.claude/skills/daily-plan-cloud/SKILL.md
+++ b/.claude/skills/daily-plan-cloud/SKILL.md
@@ -74,6 +74,12 @@ Run these in parallel:
    uv run alt-db entry list --type goal --due-within 7d
    ```
 
+6. **Tasks (Active):**
+   ```bash
+   uv run alt-db --json entry list --type task --status active
+   ```
+   Sort by priority (P0→P3, then unprioritized) then by `metadata.due_date` (earliest first, no-due last).
+
 ### Phase 3: Plan Generation
 
 Generate a daily plan autonomously using the collected data.
@@ -87,11 +93,13 @@ Generate a daily plan autonomously using the collected data.
 🔧 repo#456: issue title
 📅 Notable calendar event HH:MM
 ✅ Routine item
+📌 Task title — due today (P1)
 ```
 
 - **🔧** P0/P1 issues (auto-selected by priority)
 - **📅** Calendar events requiring preparation or action
 - **✅** Overdue and today-due routines
+- **📌** Notable tasks: status=active AND (due_date<=today OR priority in [P0,P1]). Cap at 2-3 lines; remaining active tasks live in the thread detail.
 - One item per line, icon repeated per item
 - Omit categories with no items
 - Blank line between title and items
@@ -106,6 +114,12 @@ Generate a daily plan autonomously using the collected data.
 ## Recommended Issues
 Select up to 5 recommended issues based on priority (P0/P1 first), milestone urgency, and recent activity. Do not list all open issues — the weekly plan covers that.
 - repo#123: Issue title [P1]
+- ...
+
+## Tasks (Active)
+- [P1] Title (due 2026-04-28)
+  - Sub-task: Title
+- [P2] Title
 - ...
 
 ## Routines Due
@@ -127,6 +141,7 @@ Prioritization logic (autonomous, no user input):
 - Calendar commitments are immovable
 - Overdue routines are flagged
 - Suggest time blocking based on calendar gaps
+- Possible task candidates: scan recent Discord memos collected in Phase 2 step 4. If any line is clearly actionable (concrete verb + object, optional date), include it in the thread detail under a `## Possible Task Candidates` section so the user can register it on the next interactive run. Do NOT call `entry add` autonomously — risk of spurious entries from misjudged memos is too high.
 
 ### Phase 4: Save and Post
 

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -44,6 +44,12 @@ Run these commands in parallel to collect today's context:
    - Recent memos (last 7 days): `uv run alt-db entry list --since 7d`
    - Goals with approaching deadlines: `uv run alt-db entry list --type goal --due-within 7d`
 
+6. **Tasks (Active):**
+   ```bash
+   uv run alt-db --json entry list --type task --status active
+   ```
+   These are personal tasks tracked in the entries table (separate from GitHub issues). Sort by priority (P0→P3, then unprioritized) then by `metadata.due_date` (earliest first, no-due last).
+
 ### Phase 2: Present Summary
 
 Present all gathered information organized as:
@@ -56,6 +62,12 @@ Present all gathered information organized as:
 ## Recommended Issues (GitHub)
 Select up to 5 recommended issues based on priority (P0/P1 first), milestone urgency, and recent activity. Do not list all open issues — the weekly plan covers that.
 - repo#123: Issue title [P1]
+- ...
+
+## Tasks (Active)
+- [P1] Title (due 2026-04-28)
+  - Sub-task: Title
+- [P2] Title
 - ...
 
 ## Routines Due
@@ -81,6 +93,11 @@ Discuss with the user:
 - Any tasks to defer or add?
 - Time blocking suggestions based on calendar gaps
 - Which routines to handle today?
+- Promote Discord memos to tasks: review the recent memos collected in Phase 1 step 4. For each memo line that looks like an actionable task:
+  1. Check existing tasks for similar titles via `uv run alt-db --json entry list --type task --status active` and `--status backlog` (already collected in step 6) — judge similarity semantically (not pattern-based).
+  2. If similar exists, ask: "Existing task `<title>` looks similar — register new, append note to existing, or skip?"
+  3. If no similar task exists, propose registration with draft title/status/priority/due_date and confirm with the user.
+  4. On approval, register: `uv run alt-db entry add --type task --title "<title>" --status <active|backlog> --metadata '{"priority":"...","due_date":"..."}'`
 
 ### Phase 4: Post to Discord
 
@@ -99,11 +116,13 @@ Based on the Phase 3 discussion outcome, generate a concise channel summary:
 🔧 repo#456: issue title
 📅 Notable calendar event HH:MM
 ✅ Routine item
+📌 Task title — due today (P1)
 ```
 
 - **🔧** Issues decided to work on today
 - **📅** Calendar events requiring action or attention
 - **✅** Routines to handle today
+- **📌** Notable tasks: status=active AND (due_date<=today OR priority in [P0,P1]). Cap at 2-3 lines; remaining active tasks live in the thread detail.
 - One item per line, icon repeated per item
 - Omit categories with no items
 - Blank line between title and items
@@ -114,6 +133,7 @@ The full plan reflects the discussion outcome (revised schedule, priorities, not
 
 - **Today's Schedule** — full calendar event list
 - **Recommended Issues** — curated issue candidates with priority labels
+- **Tasks (Active)** — sorted by priority then due_date; sub-tasks indented under their parent
 - **Routines Due** — overdue and upcoming
 - **Goals & Reminders** — active goals, approaching deadlines, memos
 - **Rest of Week Overview** — upcoming events and deadlines

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -44,11 +44,12 @@ Run these commands in parallel to collect today's context:
    - Recent memos (last 7 days): `uv run alt-db entry list --since 7d`
    - Goals with approaching deadlines: `uv run alt-db entry list --type goal --due-within 7d`
 
-6. **Tasks (Active):**
+6. **Tasks (Active and Backlog):**
    ```bash
    uv run alt-db --json entry list --type task --status active
+   uv run alt-db --json entry list --type task --status backlog
    ```
-   These are personal tasks tracked in the entries table (separate from GitHub issues). Sort by priority (P0→P3, then unprioritized) then by `metadata.due_date` (earliest first, no-due last).
+   These are personal tasks tracked in the entries table (separate from GitHub issues). Sort active by priority (P0→P3, then unprioritized) then by `metadata.due_date` (earliest first, no-due last). Backlog is used for duplicate detection during the Phase 3 promotion flow.
 
 ### Phase 2: Present Summary
 

--- a/.claude/skills/weekly-plan-cloud/SKILL.md
+++ b/.claude/skills/weekly-plan-cloud/SKILL.md
@@ -74,6 +74,13 @@ Run these in parallel:
    ```
    Check for stale goals: active goals NOT updated in 30+ days (those not appearing in `--since 30d` results).
 
+6. **Tasks (Active and Backlog):**
+   ```bash
+   uv run alt-db --json entry list --type task --status active
+   uv run alt-db --json entry list --type task --status backlog
+   ```
+   Sort active by priority (P0→P3, then unprioritized) then `metadata.due_date`. Sort backlog by created_at (oldest first).
+
 ### Phase 3: Plan Generation
 
 Generate a weekly plan autonomously using the collected data. Use this output format:
@@ -91,6 +98,14 @@ Generate a weekly plan autonomously using the collected data. Use this output fo
 ### Development Priorities
 - [ ] repo#123: Issue title [P1]
 - [ ] repo#456: Issue title [P2]
+
+### Tasks (Active)
+- [P1] Title (due 2026-04-28)
+- ...
+
+### Backlog Review
+- Title (added 2026-04-15)
+- ...
 
 ### Routines Due This Week
 - Mon: Clean toilet, Change toothbrush
@@ -111,6 +126,8 @@ Prioritization logic (autonomous, no user input):
 - Distribute routines across available days based on `available_days` field
 - Flag stale goals for attention
 - Suggest top 3 goals for the week based on priority and deadlines
+
+The cloud variant does NOT register new tasks and does NOT change backlog statuses. If any past-week Discord memo is clearly actionable, include it under a `## Possible Task Candidates` section so the user can register it on the next interactive weekly-plan run. Backlog tasks are listed as-is for visibility; the user will promote/cancel them interactively next week.
 
 ### Phase 4: Save and Post
 

--- a/.claude/skills/weekly-plan-cloud/SKILL.md
+++ b/.claude/skills/weekly-plan-cloud/SKILL.md
@@ -127,7 +127,7 @@ Prioritization logic (autonomous, no user input):
 - Flag stale goals for attention
 - Suggest top 3 goals for the week based on priority and deadlines
 
-The cloud variant does NOT register new tasks and does NOT change backlog statuses. If any past-week Discord memo is clearly actionable, include it under a `## Possible Task Candidates` section so the user can register it on the next interactive weekly-plan run. Backlog tasks are listed as-is for visibility; the user will promote/cancel them interactively next week.
+The cloud variant does NOT register new tasks and does NOT change backlog statuses. If any past-week Discord memo is clearly actionable, include it under a `### Possible Task Candidates` section so the user can register it on the next interactive weekly-plan run. Backlog tasks are listed as-is for visibility; the user will promote/cancel them interactively next week.
 
 ### Phase 4: Save and Post
 

--- a/.claude/skills/weekly-plan/SKILL.md
+++ b/.claude/skills/weekly-plan/SKILL.md
@@ -40,6 +40,13 @@ Use this date to compute `<monday>` (start of current week) and `<next-monday>` 
    - Entries added last week: `uv run alt-db entry list --since 7d`
    - Stale goals (no update in 30+ days): `uv run alt-db entry list --type goal --status active --since 30d` (check for goals NOT in results — those are stale)
 
+6. **Tasks (Active and Backlog):**
+   ```bash
+   uv run alt-db --json entry list --type task --status active
+   uv run alt-db --json entry list --type task --status backlog
+   ```
+   Sort active by priority (P0→P3, then unprioritized) then `metadata.due_date`. Sort backlog by created_at (oldest first — they have been waiting longest).
+
 ### Phase 2: Present Week Overview
 
 ```
@@ -54,6 +61,16 @@ Use this date to compute `<monday>` (start of current week) and `<next-monday>` 
 ### Development Priorities
 - [ ] Issue #123: ...
 - [ ] Issue #456: ...
+
+### Tasks (Active)
+- [P1] Title (due 2026-04-28)
+  - Sub-task: Title
+- [P2] Title
+- ...
+
+### Backlog Review
+- Title (added 2026-04-15)
+- ...
 
 ### Routines Due This Week
 - Mon: Wash sheets, Clean toilet
@@ -76,6 +93,8 @@ Discuss with the user:
 - Any deadlines or commitments
 - Routine batching strategy (which day for which routines)
 - Blockers or concerns
+- Promote Discord memos from the past week to tasks: for each candidate memo, check existing active/backlog tasks (collected in Phase 1 step 6), surface duplicates, and on approval register via `uv run alt-db entry add --type task --title "<title>" --status <active|backlog> --metadata '{"priority":"...","due_date":"..."}'`.
+- Review backlog: for each backlog task, ask whether to promote to `active` for the upcoming week, keep in `backlog`, or mark `cancelled` (`uv run alt-db entry update <id> --status active|cancelled`).
 
 ### Phase 4: Output
 

--- a/docs/superpowers/specs/2026-04-28-personal-task-management-design.md
+++ b/docs/superpowers/specs/2026-04-28-personal-task-management-design.md
@@ -1,0 +1,193 @@
+# Personal Task Management Design
+
+- Status: Draft
+- Date: 2026-04-28
+- Issue: [#13](https://github.com/cloveclovedev/alt/issues/13)
+
+## Background
+
+`alt` was published as a public OSS repo (`cloveclovedev/alt`). Until now, the project has used GitHub issues for all task management — both project work and life/daily tasks (per `.claude/rules/issue-management.md`). With the public repo, life tasks can no longer live in GitHub issues, so they need a new home.
+
+Three storage options were considered: an external system (e.g., Google Tasks), a private GitHub repo, or the existing `entries` table in the alt DB. The DB option was selected because:
+
+- The user already captures notes on mobile via Discord. Mobile task entry through a separate native app (Google Tasks) would split the capture flow without clear gain.
+- Daily/weekly plan skills already query `entries` for goals, memos, and routine completions. Adding `type='task'` keeps planning integrated.
+- The `entries` table absorbed routines (#14/#15) on the same "consolidate generic types via JSON metadata" philosophy. Tasks fit the same shape.
+
+## Decision Summary
+
+- New entry type `task` in the existing `entries` table. No schema migration required.
+- Mobile capture continues via Discord. Daily/weekly plan skills mediate "Discord memo → DB task" promotion interactively.
+- daily-plan and daily-plan-cloud surface notable tasks in the channel summary (📌 icon) and the full active list in the thread detail.
+- weekly-plan and weekly-plan-cloud surface the active list and a backlog review section in the (single) post body.
+- `.claude/rules/database-entries.md` is restructured to document each entry type's schema in a single per-type reference. Existing types are backfilled from current usage as part of this work.
+
+## Data Model: `type='task'`
+
+| Field | Value |
+|---|---|
+| `type` | `task` |
+| `title` | Task title (English, per entries language rule) |
+| `content` | Free-form notes, optional |
+| `status` | `active` (default), `backlog`, `done`, `cancelled` |
+| `metadata` | `{ priority?: "P0"\|"P1"\|"P2"\|"P3", due_date?: "YYYY-MM-DD" }` |
+| `parent_id` | Optional. References a parent task entry id for sub-tasks. |
+
+### Status semantics
+
+- `active` — selected to work on. Surfaces in daily-plan active list and (when notable) in summary.
+- `backlog` — captured but not committed to do soon. Reviewed in weekly-plan; may be promoted to `active` or marked `cancelled`.
+- `done` — completed.
+- `cancelled` — deliberately not doing. Distinct from `done`.
+
+### Sub-task semantics
+
+- Parent and child statuses are independent. Marking the parent `done` does not change child statuses; the user marks remaining children explicitly.
+- Display: daily-plan and weekly-plan render sub-tasks indented one level under their parent.
+
+### Promotion criteria for "notable" elevation
+
+A task qualifies for the daily-plan channel summary if `status='active'` AND (`metadata.due_date <= today` OR `metadata.priority` is `P0` or `P1`). The summary is capped at 2-3 task lines; remaining active tasks live in the thread detail.
+
+## Discord → DB Promotion Flow
+
+The promotion flow runs only in the interactive variants (`daily-plan`, `weekly-plan`). Cloud variants do NOT register tasks autonomously — they only surface candidate memos in the post for the next interactive run to handle.
+
+Interactive flow:
+
+1. Skill reads recent Discord memos via `alt-discord read` (already done for context in current skills).
+2. Skill loads existing tasks for duplicate check:
+   ```bash
+   uv run alt-db --json entry list --type task --status active
+   uv run alt-db --json entry list --type task --status backlog
+   ```
+3. For each memo line that the skill judges to be a candidate task (semantic, not pattern-based):
+   - If a similar existing task is found by title/content, surface it: "Existing task `X` looks similar — register new, append note to existing, or skip?"
+   - If no similar task exists, propose registration with a draft title/status/priority/due_date.
+4. On user approval, register:
+   ```bash
+   uv run alt-db entry add --type task \
+     --title "<title>" \
+     --status <active|backlog> \
+     --metadata '{"priority": "...", "due_date": "..."}'
+   ```
+
+Cloud variants (`daily-plan-cloud`, `weekly-plan-cloud`):
+
+- Do NOT call `entry add` for tasks. Reason: autonomous registration risks spurious entries from misjudged memos, and the user has no chance to correct.
+- MAY include a "Possible task candidates" mention in the post body for clearly actionable memos, so the user can register them on the next interactive run.
+- Same applies to backlog promotion in weekly-plan-cloud — backlog items are listed but never moved to `active` autonomously.
+
+## daily-plan / daily-plan-cloud Updates
+
+Phase 1 (data collection) gains:
+
+```bash
+uv run alt-db --json entry list --type task --status active
+```
+
+Phase 2/3 (presentation, interactive only) include the promotion flow above before generating output.
+
+Phase 4 (post to Discord) — both variants:
+
+Channel summary template gains a 📌 line per notable task (max 2-3 lines):
+
+```
+📋 <YYYY-MM-DD> (<Day>) Daily Plan
+
+🔧 repo#123: issue title
+📅 10:00 Calendar event
+✅ Routine item
+📌 Task title — due today (P1)
+```
+
+Thread detail gains a section between Recommended Issues and Routines Due:
+
+```
+## Tasks (Active)
+- [P1] Title (due 2026-04-28)
+  - Sub-task: Title
+- [P2] Title
+- ...
+```
+
+Active tasks are sorted by priority (P0 → P3, then unprioritized) then by `due_date` (earliest first, no-due last). Sub-tasks render indented under their parent regardless of their own priority.
+
+## weekly-plan / weekly-plan-cloud Updates
+
+Both variants currently post a single Discord message (no thread split). This design keeps that structure and adds two sections to the post body:
+
+```
+## Tasks (Active)
+- [P1] Title (due 2026-04-28)
+- ...
+
+## Backlog Review
+- Title (added 2026-04-15)
+- ...
+```
+
+Phase 1 (data collection) gains:
+
+```bash
+uv run alt-db --json entry list --type task --status active
+uv run alt-db --json entry list --type task --status backlog
+```
+
+Phase 3 (Interactive Goal Setting, interactive only) gains:
+
+- Discord recent-memo promotion (same as daily-plan, but spanning the past week).
+- Backlog review: for each backlog task, prompt the user to promote to `active` for the upcoming week, keep in `backlog`, or mark `cancelled`.
+
+Channel summary / thread detail restructuring of weekly-plan is out of scope — tracked separately.
+
+## Documentation: Per-Type Entries Reference
+
+`.claude/rules/database-entries.md` is restructured into:
+
+1. Overview (existing type table)
+2. Per-Type Reference (new)
+3. CLI Commands (existing, unchanged)
+4. When to Save / When NOT to Save (existing)
+5. Language (existing)
+
+Each per-type section follows this format (no bold field labels — the bullet/colon structure already separates label from value):
+
+```
+### task
+- Status: active(default) / backlog / done / cancelled
+- Metadata: { priority: "P0|P1|P2|P3" (optional), due_date: "YYYY-MM-DD" (optional) }
+- Content: free-form notes (optional)
+- Parent: optional — references parent task entry for sub-tasks
+- Lifecycle: Discord memo → daily-plan/weekly-plan promotion → active or backlog → done or cancelled
+- Consumers: daily-plan (active + notable to summary), weekly-plan (active + backlog review), webapp /entries
+```
+
+Backfill targets (current usage extracted from skills/code):
+
+- `task` (new)
+- `knowledge` / `goal` / `memo` / `tech_interest` / `business`
+- `routine_event` (per `.claude/skills/routines/SKILL.md`)
+- `body_measurement` / `body_measurement_goal` (per `webapp/src/components/body/`)
+- `nutrition_item` / `nutrition_log` / `nutrition_target` (per nutrition-check-cloud skill)
+- `daily_plan` / `weekly_plan` (per daily-plan/weekly-plan post-save step)
+
+CLI examples are kept only in the existing CLI Commands section, not duplicated per type.
+
+## Migration
+
+No migration of existing GitHub issues is required. The current `cloveclovedev/alt` open issues are project work (alt features), not life tasks; they remain in GitHub. Life-task entries are added going forward, mostly via the Discord promotion flow.
+
+If specific life tasks are already tracked elsewhere (memory, calendar) and warrant an initial backlog seed, the user adds them manually via `alt-db entry add --type task` after rollout.
+
+## Out of Scope
+
+- Dedicated CLI subcommands `alt-db task ...` (revisit if generic `entry` ergonomics become a friction point).
+- Dedicated webapp `/tasks` page (`/entries?type=task&status=active` covers it for now).
+- Google Calendar sync of task `due_date` (separate issue if needed).
+- Restructuring weekly-plan output into channel summary / thread detail (separate issue).
+- Migrating existing GitHub issues into task entries.
+
+## Open Questions
+
+None at design time.


### PR DESCRIPTION
## Summary

- Introduce `type='task'` entries in the existing `entries` table — no schema change. Statuses: `active`(default) / `backlog` / `done` / `cancelled`. Optional `metadata.priority` (P0–P3) and `metadata.due_date`. Optional sub-task hierarchy via `parent_id`.
- Restructure `.claude/rules/database-entries.md` into a per-type reference covering all 17 current entry types (Status / Metadata / Content / Parent / Title / Lifecycle / Consumers).
- Update `daily-plan` / `daily-plan-cloud` / `weekly-plan` / `weekly-plan-cloud` skills to surface tasks and mediate Discord memo → DB promotion. Interactive variants register tasks with duplicate detection; cloud variants surface candidates in `Possible Task Candidates` without autonomous registration or backlog promotion.

Design doc: `docs/superpowers/specs/2026-04-28-personal-task-management-design.md`

Closes #13.

## Test plan

- [x] Run `/daily-plan` interactively. Confirm:
  - Phase 1 collects active and backlog tasks
  - Phase 2 shows `## Tasks (Active)` section between Recommended Issues and Routines Due
  - Phase 3 prompts to promote Discord memos with semantic dedup against existing tasks
  - Phase 4 channel summary includes 📌 line for tasks due today or P0/P1 (cap 2-3)
  - Phase 4 thread detail includes `## Tasks (Active)` section
- [ ] Run `/weekly-plan` interactively. Confirm:
  - Phase 1 collects both active and backlog
  - Phase 2/post body includes `### Tasks (Active)` and `### Backlog Review` sections
  - Phase 3 prompts for Discord-memo promotion (past week) and backlog review (promote / keep / cancel per item)
- [ ] Verify next scheduled `daily-plan-cloud` and `weekly-plan-cloud` runs:
  - Do NOT call `entry add --type task`
  - Do NOT call `entry update --status active|cancelled` on backlog tasks
  - Surface notable tasks in summary (📌, daily only) and possible candidates in body when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)