### PR TITLE
feat(webapp): per-skill config UI (Phase 1: daily-plan)

### DIFF
--- a/.claude/config-defaults.yaml
+++ b/.claude/config-defaults.yaml
@@ -1,0 +1,53 @@
+# .claude/config-defaults.yaml
+#
+# OSS-shipped catalog of config params consumed by the official skill set.
+# This is the seed used by `alt-db config seed`. After seeding, the database
+# is the runtime truth; this file is not read again unless you re-seed.
+#
+# Personal additions (custom keys, edited descriptions) live in the database
+# only and are not reflected here.
+#
+# Required fields per param: type.
+# Optional: description, consumed_by, default.
+# Allowed types: string | number | boolean | array | object.
+
+params:
+  plan.discord.channel_id:
+    type: string
+    description: |
+      Discord channel ID where daily and weekly plans are posted.
+    consumed_by: [daily-plan, daily-plan-cloud, weekly-plan, weekly-plan-cloud]
+
+  plan.github.repos:
+    type: array
+    description: |
+      List of GitHub repositories (owner/name) scanned for issues during
+      daily and weekly planning.
+    consumed_by: [daily-plan, daily-plan-cloud, weekly-plan, weekly-plan-cloud]
+
+  plan.google_calendar.context:
+    type: string
+    description: |
+      Free-form text explaining how to interpret each calendar
+      (for example: "Work calendar = main job hours, mkuri = personal").
+      Read by daily-plan / weekly-plan when summarising the schedule.
+    consumed_by: [daily-plan, daily-plan-cloud, weekly-plan, weekly-plan-cloud]
+
+  daily_plan.cloud.enabled:
+    type: boolean
+    description: |
+      When true, daily-plan-cloud runs as a fallback if you have not
+      already posted a daily plan by daily_plan.cloud.fallback_time.
+      Set to false to disable the cloud fallback entirely.
+    consumed_by: [daily-plan-cloud, cloud-scheduler]
+    default: true
+
+  daily_plan.cloud.fallback_time:
+    type: string
+    description: |
+      JST time (HH:MM) at which daily-plan-cloud auto-posts when no daily
+      plan has been posted yet. Cloud-scheduler dispatches based on the
+      hour part. Phase 1: changing this requires the unified trigger cron
+      to already fire on the new hour (cron reconciliation is a follow-up).
+    consumed_by: [daily-plan-cloud, cloud-scheduler]
+    default: "10:23"

--- a/.claude/skills/cloud-scheduler/SKILL.md
+++ b/.claude/skills/cloud-scheduler/SKILL.md
@@ -49,6 +49,25 @@ For each skill in the matched row:
 2. Follow the loaded skill's instructions completely through all phases
 3. If the skill encounters an error, note the failure and proceed to the next skill in the row
 
+### Phase 2.5: Per-skill gates
+
+Some skills now read their own enable/time configuration from the `config`
+table. Apply these gates *before* invoking the relevant skill, regardless of
+the dispatch table:
+
+**daily-plan-cloud** — read both keys:
+```bash
+uv run alt-db config get daily_plan.cloud.enabled
+uv run alt-db config get daily_plan.cloud.fallback_time
+```
+
+If `daily_plan.cloud.enabled` is `false`, skip daily-plan-cloud.
+If the hour part of `daily_plan.cloud.fallback_time` (e.g. `10` from `"10:23"`)
+does not match `<hour>` from Phase 1, skip daily-plan-cloud.
+
+(All other skills retain their existing dispatch-table behaviour for now.
+Per-skill gates for them will be added in subsequent issues.)
+
 ### Phase 3: Summary
 
 After all dispatched skills have completed, output a brief summary:

--- a/README.md
+++ b/README.md
@@ -112,8 +112,36 @@ Benefits for forkers:
 
 ## Configuration
 
-- `config` table (Postgres) — App settings (Discord channels, GitHub repos, schedule preferences). Manage via `uv run alt-db config`.
-- `.env` — Credentials (database, Discord bot token). See `.env.example`.
+Configuration values live in a Postgres `config` table. Each row carries a
+`key`, a JSON `value`, and a `metadata` jsonb describing the param's
+type / description / consumed_by skills / default. Manage values via:
+
+- `uv run alt-db config get <key>` / `set <key> <json>` / `list [--with-meta]`
+- the webapp `/config` page (Phase 1 surfaces daily-plan params; more
+  skills land in subsequent phases)
+
+Credentials (DB URL, Discord token, etc.) live in `.env`, see `.env.example`.
+
+### How params are defined
+
+The repo ships `.claude/config-defaults.yaml`, a catalog of the params
+the official skill set expects. It is **not the runtime source of truth**:
+
+```bash
+uv run alt-db config seed         # insert YAML keys missing from the DB
+uv run alt-db config seed --force # also overwrite metadata of existing keys
+                                  # (value is preserved either way)
+```
+
+After seeding, the database is authoritative. Personal customisation —
+adding private keys, editing descriptions, overriding values — flows
+through the same write paths the seed CLI uses (the webapp, the
+`alt-db config` CLI, or a Claude Code conversation), and never requires
+forking the YAML. Re-running `seed` will not touch keys that exist in the
+DB but are absent from the YAML, so personal additions are safe.
+
+The design rationale lives in
+`docs/superpowers/specs/2026-04-29-config-webapp-daily-plan-design.md`.
 
 ## Development
 

--- a/db/migrations/20260429190000_add_config_metadata.sql
+++ b/db/migrations/20260429190000_add_config_metadata.sql
@@ -1,0 +1,6 @@
+-- db/migrations/20260429190000_add_config_metadata.sql
+-- Add a metadata jsonb column to config so each key can carry its own
+-- description / type / consumed_by / default. Existing rows default to '{}'.
+
+ALTER TABLE "config"
+  ADD COLUMN "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,3 +1,4 @@
-h1:NqXTU6QNj5xswJJDFfD+NoiCu0DEj9RFCLMDEXKJgrc=
+h1:OyDwsaOPJeBh1KqMfHrm0QDDxkLICC7n8zKWiRV+lcc=
 20260426115805_baseline.sql h1:VkeiefKrr1ZuGFU5jhaFHWD/D52qtjpy6fw/8wmnQNQ=
 20260426160652_add_config_table.sql h1:HJk5jU91tjJ71isK4eoWqy1x5jtZBD6hRlHm3oOL7FM=
+20260429190000_add_config_metadata.sql h1:tnftAFMXSRKBT1RdGQSgodypEYII1LZYTl4T6Aw6Qq4=

--- a/docs/superpowers/specs/2026-04-29-config-webapp-daily-plan-design.md
+++ b/docs/superpowers/specs/2026-04-29-config-webapp-daily-plan-design.md
@@ -1,0 +1,305 @@
+# Config webapp UI (Phase 1: daily-plan)
+
+Date: 2026-04-29
+Status: Approved
+Tracking: [#21](https://github.com/cloveclovedev/alt/issues/21)
+
+## Goal
+
+Make daily-plan configuration accessible to non-CLI users by surfacing it in
+the webapp. As the proof of concept, expose the params consumed by `daily-plan`
+and `daily-plan-cloud`, plus two new schedule-control params (`daily_plan.cloud.enabled`,
+`daily_plan.cloud.fallback_time`). Establish the per-skill config UI mechanism
+so later phases can extend to other skills (`weekly-plan`, `x-draft`, etc.).
+
+## Philosophy
+
+`config` is a key-value store of system settings, distinct in nature from
+`entries` (an append-only log). The "single table" philosophy applies to
+`entries`; for `config`, structured per-key metadata is appropriate.
+
+The shipped repository carries a YAML catalog of the params each official skill
+expects. The catalog is **not the runtime source of truth** — it is a
+git-managed set of definitions used to bootstrap or update the database.
+After bootstrap, the database is authoritative. Personal customisation
+(adding a private key, editing a description, overriding a value) flows
+through the same writes the seed CLI uses; it does not require touching the
+YAML.
+
+This preserves three properties at once:
+- new clones can come up with sensible defaults (forker friendliness),
+- official skill changes get reviewable diffs (catalog in git),
+- individuals can extend the system freely without forking the repo.
+
+## Non-goals (Phase 1)
+
+- Editing param metadata (description / type / consumed_by) from the webapp.
+  Phase 1 webapp edits values only.
+- Adding a "create new param" UI in the webapp. Custom params are added via
+  CLI (`alt-db config set` / `set-meta`) or via Claude Code conversations.
+- Reconciling the cloud-scheduler cron schedule from config. Phase 1 reads
+  `daily_plan.cloud.enabled` / `fallback_time` inside the existing dispatch
+  loop only; the trigger cron itself stays as-is. Tracked in a follow-up
+  issue.
+- Editing the `routines` collection through atomic-key forms. The collection
+  needs its own dedicated editor (separate issue).
+- Other skills (`weekly-plan`, `x-draft`, `x-post`, `nutrition-check`,
+  `wake-check`, `routines`). Phase 2.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  .claude/config-defaults.yaml                              │
+│  (skill-author-edited initial param catalog, git-tracked)  │
+└─────────────────┬──────────────────────────────────────────┘
+                  │  uv run alt-db config seed (idempotent)
+                  ▼
+┌────────────────────────────────────────────────────────────┐
+│  config table (Neon)                                       │
+│    key | value (jsonb) | metadata (jsonb) | timestamps     │
+│                                                            │
+│  metadata = { type, description, consumed_by, default }    │
+└──┬──────────────┬─────────────────────────┬────────────────┘
+   │              │                         │
+   ▼              ▼                         ▼
+webapp           cloud-scheduler           daily-plan / other
+(read+write      (read enabled +           skills
+ value)           fallback_time)           (read as today)
+```
+
+Three write paths land in the same `config` table and are equal citizens:
+- `alt-db config seed` (YAML → DB, insert-if-missing)
+- `alt-db config set` / `set-meta` (CLI)
+- webapp `/config` page (Server Action, value only in Phase 1)
+
+The runtime truth is always the database row.
+
+## Data model
+
+### `config` table — `metadata` column
+
+A new `metadata` jsonb column is added to the existing `config` table:
+
+```sql
+ALTER TABLE config
+  ADD COLUMN metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+```
+
+Existing rows retain their `value` and receive `metadata = {}`.
+
+`metadata` shape (all fields optional except `type`):
+
+```json
+{
+  "type": "string | number | boolean | array | object",
+  "description": "Human-readable explanation, may be multi-line.",
+  "consumed_by": ["daily-plan", "weekly-plan"],
+  "default": null
+}
+```
+
+### YAML catalog — `.claude/config-defaults.yaml`
+
+A single file at `.claude/config-defaults.yaml` (sibling to `skills/`) lists
+the params shipped with the OSS repo. Skill-specific and shared params live
+together; `consumed_by` carries the ownership information.
+
+```yaml
+params:
+  plan.discord.channel_id:
+    type: string
+    description: |
+      Discord channel ID where daily and weekly plans are posted.
+    consumed_by: [daily-plan, weekly-plan]
+
+  plan.github.repos:
+    type: array
+    description: |
+      List of GitHub repositories (owner/name) to scan for issues during
+      daily and weekly planning.
+    consumed_by: [daily-plan, weekly-plan]
+
+  plan.google_calendar.context:
+    type: string
+    description: |
+      Free-form context describing how to interpret each calendar
+      (e.g., "Work calendar = main job hours, mkuri = personal").
+    consumed_by: [daily-plan, weekly-plan]
+
+  daily_plan.cloud.enabled:
+    type: boolean
+    description: |
+      When true, daily-plan-cloud runs as a fallback if you have not
+      manually posted a daily plan by fallback_time.
+    consumed_by: [daily-plan-cloud, cloud-scheduler]
+    default: true
+
+  daily_plan.cloud.fallback_time:
+    type: string
+    description: |
+      JST time (HH:MM) at which daily-plan-cloud auto-posts if no daily plan
+      has been posted yet. Cloud-scheduler dispatches based on the hour part.
+    consumed_by: [daily-plan-cloud, cloud-scheduler]
+    default: "10:23"
+```
+
+YAML never contains personal values (channel IDs, repo names). Defaults are
+limited to safe, non-secret fallbacks.
+
+## Components
+
+| # | Component | Purpose |
+|---|---|---|
+| 1 | DB migration `<ts>_add_config_metadata.sql` | Add `metadata jsonb` column |
+| 2 | `.claude/config-defaults.yaml` | Catalog of params shipped with the OSS skill set |
+| 3 | `src/alt_db/config.py` | Add `set_meta(key, metadata)`, `list_with_meta()`, `load_yaml_defaults()`, `seed(force=False)` |
+| 4 | `alt-db` CLI | New subcommands: `config seed [--force]`, `config set-meta <key> <json>`, `config list --with-meta` |
+| 5 | `webapp/src/lib/config.ts` | Add `listConfigsWithMeta()`, `setConfigValues(updates)` |
+| 6 | `webapp/src/app/config/` | New route: `page.tsx` (skill tabs index) and per-skill subroute / tab components |
+| 7 | `webapp/src/app/config/actions.ts` | Server Action `saveConfigValues(updates: { key, value }[])`, auth-gated |
+| 8 | `webapp/src/components/nav.tsx` | Add `Config` nav link |
+| 9 | `.claude/skills/cloud-scheduler/SKILL.md` | Read `daily_plan.cloud.enabled` / `.fallback_time` before dispatching daily-plan-cloud |
+| 10 | `README.md` | Add "Configuration" philosophy section explaining YAML catalog vs DB truth |
+| 11 | Follow-up issues | Cron reconciler, webapp metadata editor, `routines` collection editor |
+
+## Data flows
+
+### A. New environment bootstrap (forker)
+
+1. `atlas migrate apply` — config table receives `metadata` column.
+2. `uv run alt-db config seed` — for each YAML param, insert a row if absent;
+   set `metadata` from YAML; leave `value` at NULL when no `default`, otherwise
+   at `default`. Existing rows are not touched.
+3. Open webapp `/config` — params with no value display as "unset".
+4. User fills values via the form — Server Action writes `value`.
+5. `/daily-plan` runs as today; `getConfig(key)` reads value as before.
+
+### B. Existing user (this project)
+
+1. `atlas migrate apply` — column added; existing rows get `metadata = {}`.
+2. `uv run alt-db config seed` — backfills `metadata` for keys present in YAML;
+   does not touch `value`. Personal keys absent from YAML are untouched
+   (`metadata` stays `{}`).
+3. Webapp `/config` shows existing values; user can edit as needed.
+
+### C. webapp value edit
+
+```
+form submit (global Save → all dirty fields)
+  → Server Action saveConfigValues([{key, value}, ...])
+  → auth check (existing GitHub OAuth allowlist)
+  → for each update, cast value per metadata.type
+  → run all UPDATEs in a single transaction
+  → revalidatePath('/config')
+  → return { ok, errors? } where errors maps key → message
+```
+
+### D. cloud-scheduler dispatch (new behaviour, daily-plan-cloud only in Phase 1)
+
+The cloud-scheduler dispatch table stays hard-coded. Inside the existing
+dispatch row for daily-plan-cloud, two reads are added:
+
+```
+enabled       = getConfig('daily_plan.cloud.enabled', default=true)
+fallback_time = getConfig('daily_plan.cloud.fallback_time', default="10:23")
+fallback_hour = parseInt(fallback_time.split(":")[0])
+
+if enabled and current_jst_hour == fallback_hour:
+    invoke daily-plan-cloud
+else:
+    skip
+```
+
+The cron schedule itself is not modified in Phase 1. If the user changes
+`fallback_time` to an hour the unified trigger does not fire on, daily-plan-cloud
+will not run until the cron is reconciled — that is the follow-up issue's job.
+
+### E. Personal param addition (Phase 1: CLI / Claude Code only)
+
+```
+uv run alt-db config set my.custom.key '"value"'
+uv run alt-db config set-meta my.custom.key \
+  '{"type":"string","description":"my note","consumed_by":["myskill"]}'
+```
+
+The webapp displays the new param in the tab matching `consumed_by`. Params
+whose `consumed_by` is empty or references an unknown skill appear in a
+synthetic `Custom` tab so personal additions are not lost.
+
+## Webapp UI
+
+Top-level nav adds a `Config` entry. The `/config` page renders skill tabs:
+
+- `daily-plan`
+- `Custom` (params with empty / unknown `consumed_by`)
+
+In Phase 1 only `daily-plan` and `Custom` exist; later phases add more
+without changing the mechanism.
+
+Inside each tab, params are listed in YAML / DB order. Phase 1 does not add
+visual sub-grouping by dot-prefix. Each row shows:
+
+- the full key (e.g., `plan.discord.channel_id`)
+- the description from metadata (italic, smaller)
+- a form input chosen by `metadata.type`:
+  - `string` → `<Textarea>` if the current value contains a newline,
+    otherwise `<Input>`
+  - `number` → `<Input type="number">`
+  - `boolean` → `<Switch>`
+  - `array` → repeated `<Input>` rows with add/remove buttons (Phase 1
+    assumes string items)
+  - `object` → JSON `<Textarea>` (no structured editor in Phase 1)
+
+A single global Save button at the bottom of each tab submits all dirty
+fields in one Server Action call. Per-row Save is not added in Phase 1.
+
+A param appearing in multiple `consumed_by` skills is shown identically in
+each tab (it is the same key); editing in one tab updates the same DB row.
+
+## Error handling
+
+- **Type mismatch on save** — Server Action attempts cast per `metadata.type`,
+  returns `{ ok: false, error }` on failure for the form to surface inline.
+- **Missing metadata** — webapp infers a fallback type from the current
+  `value`'s JSON type and shows `(no description set)` placeholder. Such params
+  appear in the `Custom` tab.
+- **YAML parse error during seed** — CLI exits non-zero, prints offending key,
+  applies nothing (single transaction).
+- **YAML key absent in DB** — `seed` inserts with NULL value (or `default`).
+- **DB key absent in YAML** — `seed` does not touch it; preserves personal
+  customisation.
+- **Auth** — `/config` route protected by existing GitHub OAuth allowlist.
+- **Concurrency** — last-write-wins via `updated_at`; acceptable for a
+  single-user tool.
+
+## Testing
+
+- **Python (`tests/`)**:
+  - `test_config_meta.py`: `set_meta`, `list_with_meta`, `seed (insert-if-missing)`,
+    `seed --force` (overwrites metadata, preserves value).
+  - Verify YAML parsing surfaces a clear error on malformed input.
+- **Webapp (`webapp/src/__tests__/`)**:
+  - `config.test.ts`: `listConfigsWithMeta()` returns expected shape; Server
+    Action casts each `metadata.type` correctly.
+- **Manual smoke (PR review)**:
+  - `npm run dev` → open `/config` → edit each type of field → reload, confirm
+    persistence.
+  - Set `daily_plan.cloud.enabled = false`, invoke cloud-scheduler skill
+    directly with the matching JST hour mocked; confirm daily-plan-cloud is
+    skipped.
+
+## Open follow-ups (separate issues)
+
+- **Cron reconciler** — Claude Code skill (or `alt-db` subcommand) that reads
+  every `*.cloud.fallback_time` from config and updates the unified
+  cloud-scheduler trigger's cron via `CronCreate`/`CronList`/`CronDelete`.
+  Required before adding cloud variants for skills whose hour differs from
+  the current trigger schedule.
+- **Webapp metadata editor** — UI to add new keys, edit description / type /
+  consumed_by, alongside the value editing introduced in Phase 1.
+- **`routines` collection editor** — dedicated UI for the `routines` JSON
+  object (add / edit / remove individual routines), distinct from atomic-key
+  forms.
+- **Phase 2 skills** — extend the same mechanism to `weekly-plan`, `x-draft`,
+  `x-post`, `nutrition-check`, `wake-check`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "CLI tools for alt second brain"
 requires-python = ">=3.12"
 dependencies = [
     "python-dotenv>=1.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/alt_db/cli.py
+++ b/src/alt_db/cli.py
@@ -2,10 +2,30 @@
 
 import argparse
 import json
+import os
 import sys
 
 from .connection import NeonHTTP
 from . import entries
+
+
+def _default_seed_path() -> str:
+    """Resolve the default config-defaults.yaml path.
+
+    Walks up from CWD looking for .claude/config-defaults.yaml, falling back
+    to a path relative to CWD if not found.
+    """
+    cwd = os.getcwd()
+    cur = cwd
+    while True:
+        candidate = os.path.join(cur, ".claude", "config-defaults.yaml")
+        if os.path.exists(candidate):
+            return candidate
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    return os.path.join(cwd, ".claude", "config-defaults.yaml")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -68,10 +88,22 @@ def build_parser() -> argparse.ArgumentParser:
     # config list
     config_list = config_sub.add_parser("list")
     config_list.add_argument("--prefix")
+    config_list.add_argument("--with-meta", dest="with_meta", action="store_true")
 
     # config delete
     config_delete = config_sub.add_parser("delete")
     config_delete.add_argument("key")
+
+    # config set-meta
+    config_set_meta = config_sub.add_parser("set-meta")
+    config_set_meta.add_argument("key")
+    config_set_meta.add_argument("metadata", help="JSON metadata")
+
+    # config seed
+    config_seed = config_sub.add_parser("seed")
+    config_seed.add_argument("--force", action="store_true")
+    config_seed.add_argument("--file", default=None,
+        help="Path to YAML defaults (defaults to .claude/config-defaults.yaml relative to repo root)")
 
     return parser
 
@@ -194,12 +226,24 @@ def _handle_config(db, args, use_json: bool):
             print(f"Set {args.key}")
 
     elif args.action == "list":
-        results = config_mod.list_configs(db, prefix=args.prefix)
-        if use_json:
-            print(json.dumps(results, default=str))
+        if args.with_meta:
+            results = config_mod.list_with_meta(db, prefix=args.prefix)
+            if use_json:
+                print(json.dumps(results, default=str))
+            else:
+                for row in results:
+                    desc = row["metadata"].get("description", "").strip().split("\n")[0]
+                    if desc:
+                        print(f"{row['key']} = {json.dumps(row['value'])}  # {desc}")
+                    else:
+                        print(f"{row['key']} = {json.dumps(row['value'])}")
         else:
-            for row in results:
-                print(f"{row['key']} = {json.dumps(row['value'])}")
+            results = config_mod.list_configs(db, prefix=args.prefix)
+            if use_json:
+                print(json.dumps(results, default=str))
+            else:
+                for row in results:
+                    print(f"{row['key']} = {json.dumps(row['value'])}")
 
     elif args.action == "delete":
         if config_mod.delete(db, args.key):
@@ -207,3 +251,27 @@ def _handle_config(db, args, use_json: bool):
         else:
             print(f"Key not found: {args.key}", file=sys.stderr)
             sys.exit(1)
+
+    elif args.action == "set-meta":
+        metadata = json.loads(args.metadata)
+        if not isinstance(metadata, dict):
+            print("Error: metadata must be a JSON object", file=sys.stderr)
+            sys.exit(1)
+        config_mod.set_meta(db, args.key, metadata)
+        if use_json:
+            print(json.dumps({"key": args.key}))
+        else:
+            print(f"Set metadata for {args.key}")
+
+    elif args.action == "seed":
+        path = args.file or _default_seed_path()
+        counts = config_mod.seed(db, path, force=args.force)
+        if use_json:
+            print(json.dumps(counts))
+        else:
+            print(
+                f"Seeded from {path}: "
+                f"{counts['inserted']} inserted, "
+                f"{counts['updated']} updated, "
+                f"{counts['skipped']} skipped"
+            )

--- a/src/alt_db/config.py
+++ b/src/alt_db/config.py
@@ -1,6 +1,7 @@
 """Config CRUD operations."""
 
 import json
+import yaml
 from typing import Any
 
 from .connection import NeonHTTP
@@ -88,3 +89,60 @@ def _row_to_dict_with_meta(row) -> dict:
         "created_at": str(row[3]),
         "updated_at": str(row[4]),
     }
+
+
+def load_yaml_defaults(path: str) -> dict[str, dict]:
+    """Load and validate the YAML param catalog. Returns {key: meta_dict}."""
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    params = raw.get("params", {})
+    if not isinstance(params, dict):
+        raise ValueError(f"{path}: params must be a mapping (got {type(params).__name__})")
+    out: dict[str, dict] = {}
+    for key, meta in params.items():
+        if not isinstance(meta, dict):
+            raise ValueError(f"{path}: {key}: param entry must be a mapping")
+        if "type" not in meta:
+            raise ValueError(f"{path}: {key}: missing required field 'type'")
+        if meta["type"] not in ("string", "number", "boolean", "array", "object"):
+            raise ValueError(f"{path}: {key}: invalid type '{meta['type']}'")
+        out[key] = meta
+    return out
+
+
+def seed(db: NeonHTTP, yaml_path: str, force: bool = False) -> dict[str, int]:
+    """Idempotently apply a YAML param catalog to the config table.
+
+    - Missing keys are inserted with value = meta.default (or NULL) and the
+      full meta as metadata.
+    - Existing keys are skipped unless force=True; with force, only the
+      metadata is overwritten (the value is preserved).
+    - Keys present in DB but absent from YAML are never touched.
+
+    Returns a counts dict: {"inserted": int, "updated": int, "skipped": int}.
+    """
+    catalog = load_yaml_defaults(yaml_path)
+    counts = {"inserted": 0, "updated": 0, "skipped": 0}
+    for key, meta in catalog.items():
+        existing = db.execute(
+            "SELECT 1 FROM config WHERE key = $1",
+            [key],
+        )
+        if existing.row_count == 0:
+            default_value = meta.get("default", None)
+            db.execute(
+                """INSERT INTO config (key, value, metadata)
+                   VALUES ($1, $2::jsonb, $3::jsonb)""",
+                [key, json.dumps(default_value), json.dumps(meta)],
+            )
+            counts["inserted"] += 1
+        elif force:
+            db.execute(
+                """UPDATE config SET metadata = $2::jsonb, updated_at = now()
+                   WHERE key = $1""",
+                [key, json.dumps(meta)],
+            )
+            counts["updated"] += 1
+        else:
+            counts["skipped"] += 1
+    return counts

--- a/src/alt_db/config.py
+++ b/src/alt_db/config.py
@@ -52,3 +52,39 @@ def delete(db: NeonHTTP, key: str) -> bool:
     """Delete a config entry. Returns True if deleted."""
     result = db.execute("DELETE FROM config WHERE key = $1", [key])
     return result.row_count > 0
+
+
+def set_meta(db: NeonHTTP, key: str, metadata: dict) -> None:
+    """Upsert metadata for a config key. Creates the row with value=null if absent.
+    Does not modify value of existing rows."""
+    db.execute(
+        """INSERT INTO config (key, value, metadata) VALUES ($1, 'null'::jsonb, $2::jsonb)
+           ON CONFLICT (key) DO UPDATE
+             SET metadata = EXCLUDED.metadata, updated_at = now()""",
+        [key, json.dumps(metadata)],
+    )
+
+
+def list_with_meta(db: NeonHTTP, prefix: str | None = None) -> list[dict]:
+    """List config rows including metadata. Same shape as list_configs but
+    each dict also has a 'metadata' field."""
+    if prefix is not None:
+        result = db.execute(
+            "SELECT key, value::text, metadata::text, created_at, updated_at FROM config WHERE key LIKE $1 ORDER BY key",
+            [f"{prefix}%"],
+        )
+    else:
+        result = db.execute(
+            "SELECT key, value::text, metadata::text, created_at, updated_at FROM config ORDER BY key"
+        )
+    return [_row_to_dict_with_meta(row) for row in result.rows]
+
+
+def _row_to_dict_with_meta(row) -> dict:
+    return {
+        "key": row[0],
+        "value": json.loads(row[1]),
+        "metadata": json.loads(row[2]),
+        "created_at": str(row[3]),
+        "updated_at": str(row[4]),
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for config operations."""
 
+import json
+
 from alt_db import config
 
 
@@ -128,3 +130,43 @@ def test_delete_existing_returns_true(config_db):
 def test_delete_missing_returns_false(config_db):
     client, _ = config_db
     assert config.delete(client, "test.delete.never_existed") is False
+
+
+def test_set_meta_creates_row_when_key_absent(config_db):
+    client, keys = config_db
+    keys.append("test.config.meta_only")
+    config.set_meta(client, "test.config.meta_only", {"type": "string", "description": "x"})
+    rows = client.execute(
+        "SELECT value::text, metadata::text FROM config WHERE key = $1",
+        ["test.config.meta_only"],
+    ).rows
+    assert len(rows) == 1
+    assert rows[0][0] == "null"  # value defaults to JSON null
+    assert json.loads(rows[0][1]) == {"type": "string", "description": "x"}
+
+
+def test_set_meta_updates_existing_row_metadata_only(config_db):
+    client, keys = config_db
+    keys.append("test.config.meta_update")
+    config.set(client, "test.config.meta_update", "real-value")
+    config.set_meta(client, "test.config.meta_update", {"type": "string", "description": "y"})
+    assert config.get(client, "test.config.meta_update") == "real-value"
+    meta_row = client.execute(
+        "SELECT metadata::text FROM config WHERE key = $1",
+        ["test.config.meta_update"],
+    ).rows[0]
+    assert json.loads(meta_row[0]) == {"type": "string", "description": "y"}
+
+
+def test_list_with_meta_returns_metadata(config_db):
+    client, keys = config_db
+    keys.extend(["test.lwm.a", "test.lwm.b"])
+    config.set(client, "test.lwm.a", 1)
+    config.set_meta(client, "test.lwm.a", {"type": "number"})
+    config.set(client, "test.lwm.b", "v")
+    results = config.list_with_meta(client, prefix="test.lwm.")
+    found = {r["key"]: r for r in results}
+    assert found["test.lwm.a"]["value"] == 1
+    assert found["test.lwm.a"]["metadata"] == {"type": "number"}
+    assert found["test.lwm.b"]["value"] == "v"
+    assert found["test.lwm.b"]["metadata"] == {}

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -47,3 +47,39 @@ def test_config_delete_args():
     args = parser.parse_args(["config", "delete", "x.product_links.old"])
     assert args.action == "delete"
     assert args.key == "x.product_links.old"
+
+
+def test_config_set_meta_args():
+    parser = build_parser()
+    args = parser.parse_args(["config", "set-meta", "plan.discord.channel_id", '{"type":"string"}'])
+    assert args.action == "set-meta"
+    assert args.key == "plan.discord.channel_id"
+    assert args.metadata == '{"type":"string"}'
+
+
+def test_config_list_with_meta_flag():
+    parser = build_parser()
+    args = parser.parse_args(["config", "list", "--with-meta"])
+    assert args.action == "list"
+    assert args.with_meta is True
+
+
+def test_config_list_with_meta_default_false():
+    parser = build_parser()
+    args = parser.parse_args(["config", "list"])
+    assert args.with_meta is False
+
+
+def test_config_seed_default_path():
+    parser = build_parser()
+    args = parser.parse_args(["config", "seed"])
+    assert args.action == "seed"
+    assert args.force is False
+    assert args.file is None  # uses default path resolution
+
+
+def test_config_seed_with_force_and_file():
+    parser = build_parser()
+    args = parser.parse_args(["config", "seed", "--force", "--file", "custom.yaml"])
+    assert args.force is True
+    assert args.file == "custom.yaml"

--- a/tests/test_config_seed.py
+++ b/tests/test_config_seed.py
@@ -1,0 +1,147 @@
+"""Tests for config seed: load_yaml_defaults + seed."""
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from alt_db import config
+
+
+def test_load_yaml_defaults_parses_params(tmp_path: Path):
+    yaml_file = tmp_path / "defaults.yaml"
+    yaml_file.write_text(textwrap.dedent("""
+        params:
+          plan.discord.channel_id:
+            type: string
+            description: Discord channel
+            consumed_by: [daily-plan, weekly-plan]
+          daily_plan.cloud.enabled:
+            type: boolean
+            description: |
+              Enable fallback.
+            default: true
+    """))
+    result = config.load_yaml_defaults(str(yaml_file))
+    assert "plan.discord.channel_id" in result
+    assert result["plan.discord.channel_id"]["type"] == "string"
+    assert result["plan.discord.channel_id"]["consumed_by"] == ["daily-plan", "weekly-plan"]
+    assert result["daily_plan.cloud.enabled"]["default"] is True
+
+
+def test_load_yaml_defaults_rejects_malformed(tmp_path: Path):
+    yaml_file = tmp_path / "bad.yaml"
+    yaml_file.write_text("params: [not, a, mapping]\n")
+    with pytest.raises(ValueError, match="params must be a mapping"):
+        config.load_yaml_defaults(str(yaml_file))
+
+
+def test_load_yaml_defaults_requires_type(tmp_path: Path):
+    yaml_file = tmp_path / "no_type.yaml"
+    yaml_file.write_text(textwrap.dedent("""
+        params:
+          some.key:
+            description: missing type
+    """))
+    with pytest.raises(ValueError, match="some.key.*type"):
+        config.load_yaml_defaults(str(yaml_file))
+
+
+def test_seed_inserts_missing_key_with_default(config_db, tmp_path: Path):
+    client, keys = config_db
+    keys.append("test.seed.new_key")
+    yaml_file = tmp_path / "defaults.yaml"
+    yaml_file.write_text(textwrap.dedent("""
+        params:
+          test.seed.new_key:
+            type: boolean
+            description: A test key
+            default: true
+    """))
+    counts = config.seed(client, str(yaml_file))
+    assert counts == {"inserted": 1, "updated": 0, "skipped": 0}
+    assert config.get(client, "test.seed.new_key") is True
+    rows = client.execute(
+        "SELECT metadata::text FROM config WHERE key = $1",
+        ["test.seed.new_key"],
+    ).rows
+    assert json.loads(rows[0][0])["description"] == "A test key"
+
+
+def test_seed_inserts_missing_key_without_default_uses_null(config_db, tmp_path: Path):
+    client, keys = config_db
+    keys.append("test.seed.no_default")
+    yaml_file = tmp_path / "defaults.yaml"
+    yaml_file.write_text(textwrap.dedent("""
+        params:
+          test.seed.no_default:
+            type: string
+            description: No default
+    """))
+    counts = config.seed(client, str(yaml_file))
+    assert counts == {"inserted": 1, "updated": 0, "skipped": 0}
+    assert config.get(client, "test.seed.no_default") is None
+
+
+def test_seed_skips_existing_row_without_force(config_db, tmp_path: Path):
+    client, keys = config_db
+    keys.append("test.seed.exists")
+    config.set(client, "test.seed.exists", "user-value")
+    config.set_meta(client, "test.seed.exists", {"type": "string", "description": "old"})
+    yaml_file = tmp_path / "defaults.yaml"
+    yaml_file.write_text(textwrap.dedent("""
+        params:
+          test.seed.exists:
+            type: string
+            description: new description
+    """))
+    counts = config.seed(client, str(yaml_file), force=False)
+    assert counts == {"inserted": 0, "updated": 0, "skipped": 1}
+    # value untouched, metadata untouched
+    assert config.get(client, "test.seed.exists") == "user-value"
+    rows = client.execute(
+        "SELECT metadata::text FROM config WHERE key = $1",
+        ["test.seed.exists"],
+    ).rows
+    assert json.loads(rows[0][0])["description"] == "old"
+
+
+def test_seed_force_updates_metadata_only_preserves_value(config_db, tmp_path: Path):
+    client, keys = config_db
+    keys.append("test.seed.force")
+    config.set(client, "test.seed.force", "user-value")
+    config.set_meta(client, "test.seed.force", {"type": "string", "description": "old"})
+    yaml_file = tmp_path / "defaults.yaml"
+    yaml_file.write_text(textwrap.dedent("""
+        params:
+          test.seed.force:
+            type: string
+            description: new description
+            default: "ignored-on-existing-row"
+    """))
+    counts = config.seed(client, str(yaml_file), force=True)
+    assert counts == {"inserted": 0, "updated": 1, "skipped": 0}
+    assert config.get(client, "test.seed.force") == "user-value"  # preserved!
+    rows = client.execute(
+        "SELECT metadata::text FROM config WHERE key = $1",
+        ["test.seed.force"],
+    ).rows
+    assert json.loads(rows[0][0])["description"] == "new description"
+
+
+def test_seed_does_not_touch_keys_absent_from_yaml(config_db, tmp_path: Path):
+    client, keys = config_db
+    keys.append("test.seed.personal")
+    config.set(client, "test.seed.personal", "private")
+    yaml_file = tmp_path / "defaults.yaml"
+    yaml_file.write_text(textwrap.dedent("""
+        params:
+          test.seed.unrelated:
+            type: string
+            description: Unrelated
+    """))
+    keys.append("test.seed.unrelated")
+    counts = config.seed(client, str(yaml_file), force=True)
+    assert counts == {"inserted": 1, "updated": 0, "skipped": 0}
+    assert config.get(client, "test.seed.personal") == "private"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -16,7 +17,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "python-dotenv", specifier = ">=1.0" }]
+requires-dist = [
+    { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]
@@ -89,4 +93,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]

--- a/webapp/src/__tests__/config.test.ts
+++ b/webapp/src/__tests__/config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest"
+import { castValueByType } from "@/lib/config"
+
+describe("castValueByType", () => {
+  it("returns string as-is for type=string", () => {
+    expect(castValueByType("hello", "string")).toBe("hello")
+  })
+
+  it("parses number for type=number", () => {
+    expect(castValueByType("42", "number")).toBe(42)
+    expect(castValueByType("3.14", "number")).toBe(3.14)
+  })
+
+  it("throws on invalid number", () => {
+    expect(() => castValueByType("not-a-number", "number")).toThrow()
+  })
+
+  it("returns true/false for type=boolean", () => {
+    expect(castValueByType("true", "boolean")).toBe(true)
+    expect(castValueByType("false", "boolean")).toBe(false)
+    expect(castValueByType(true, "boolean")).toBe(true)
+  })
+
+  it("parses JSON for type=array", () => {
+    expect(castValueByType('["a","b"]', "array")).toEqual(["a", "b"])
+  })
+
+  it("throws when array JSON is not an array", () => {
+    expect(() => castValueByType('{"a":1}', "array")).toThrow()
+  })
+
+  it("parses JSON for type=object", () => {
+    expect(castValueByType('{"a":1}', "object")).toEqual({ a: 1 })
+  })
+
+  it("throws when object JSON is not an object", () => {
+    expect(() => castValueByType('[1,2]', "object")).toThrow()
+  })
+
+  it("falls back to identity for unknown type", () => {
+    expect(castValueByType("x", "unknown")).toBe("x")
+  })
+})

--- a/webapp/src/app/config/actions.ts
+++ b/webapp/src/app/config/actions.ts
@@ -1,0 +1,54 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { auth } from "@/lib/auth"
+import {
+  castValueByType,
+  listConfigsWithMeta,
+  setConfigValues,
+} from "@/lib/config"
+
+export interface SaveResult {
+  ok: boolean
+  errors?: Record<string, string>
+}
+
+export async function saveConfigValues(
+  updates: Array<{ key: string; rawValue: unknown }>
+): Promise<SaveResult> {
+  const session = await auth()
+  if (!session?.user) {
+    return { ok: false, errors: { _: "Unauthenticated" } }
+  }
+
+  const all = await listConfigsWithMeta()
+  const byKey = new Map(all.map((r) => [r.key, r]))
+
+  const cast: Array<{ key: string; value: unknown }> = []
+  const errors: Record<string, string> = {}
+
+  for (const u of updates) {
+    const meta = byKey.get(u.key)?.metadata
+    const type = meta?.type ?? inferType(byKey.get(u.key)?.value)
+    try {
+      cast.push({ key: u.key, value: castValueByType(u.rawValue, type) })
+    } catch (e) {
+      errors[u.key] = e instanceof Error ? e.message : String(e)
+    }
+  }
+
+  if (Object.keys(errors).length > 0) return { ok: false, errors }
+
+  await setConfigValues(cast)
+  revalidatePath("/config")
+  return { ok: true }
+}
+
+function inferType(value: unknown): string {
+  if (typeof value === "string") return "string"
+  if (typeof value === "number") return "number"
+  if (typeof value === "boolean") return "boolean"
+  if (Array.isArray(value)) return "array"
+  if (value !== null && typeof value === "object") return "object"
+  return "string"
+}

--- a/webapp/src/app/config/page.tsx
+++ b/webapp/src/app/config/page.tsx
@@ -16,6 +16,18 @@ export default async function ConfigPage(props: {
   const all = await listConfigsWithMeta()
   const tabs = computeTabs(all)
   const active = sp.tab && tabs.includes(sp.tab) ? sp.tab : tabs[0]
+
+  if (!active) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">Config</h1>
+        <p className="text-muted-foreground">
+          No config rows found. Run <code>uv run alt-db config seed</code> to bootstrap.
+        </p>
+      </div>
+    )
+  }
+
   const rows = filterByTab(all, active)
 
   return (

--- a/webapp/src/app/config/page.tsx
+++ b/webapp/src/app/config/page.tsx
@@ -1,0 +1,68 @@
+import { listConfigsWithMeta } from "@/lib/config"
+import type { ConfigRow } from "@/lib/config"
+import { ConfigForm } from "@/components/config/config-form"
+import { TabsNav } from "@/components/config/tabs-nav"
+
+const PHASE_1_SKILLS = ["daily-plan"] as const
+
+interface SearchParams {
+  tab?: string
+}
+
+export default async function ConfigPage(props: {
+  searchParams: Promise<SearchParams>
+}) {
+  const sp = await props.searchParams
+  const all = await listConfigsWithMeta()
+  const tabs = computeTabs(all)
+  const active = sp.tab && tabs.includes(sp.tab) ? sp.tab : tabs[0]
+  const rows = filterByTab(all, active)
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Config</h1>
+
+      <TabsNav tabs={tabs} active={active} />
+
+      {rows.length === 0 ? (
+        <p className="text-muted-foreground">No params for this tab.</p>
+      ) : (
+        <ConfigForm rows={rows} />
+      )}
+    </div>
+  )
+}
+
+function computeTabs(rows: ConfigRow[]): string[] {
+  const owned = new Set<string>()
+  let hasUnowned = false
+  for (const r of rows) {
+    const consumers = r.metadata.consumed_by ?? []
+    if (consumers.length === 0) {
+      if (!r.key.startsWith("_")) hasUnowned = true
+      continue
+    }
+    for (const c of consumers) owned.add(c)
+  }
+  // Phase 1 only surfaces daily-plan related skills + Custom; restrict here so
+  // we do not accidentally show weekly-plan, x-draft, etc. that have not been
+  // designed yet.
+  const phase1 = PHASE_1_SKILLS.filter((s) =>
+    Array.from(owned).some((o) => o === s || o.startsWith(s + "-") || o === s + "-cloud")
+  )
+  return [...phase1, ...(hasUnowned ? ["Custom"] : [])]
+}
+
+function filterByTab(rows: ConfigRow[], tab: string): ConfigRow[] {
+  if (tab === "Custom") {
+    return rows.filter(
+      (r) => !r.key.startsWith("_") && (r.metadata.consumed_by ?? []).length === 0
+    )
+  }
+  return rows.filter((r) => {
+    const consumers = r.metadata.consumed_by ?? []
+    return consumers.some(
+      (c) => c === tab || c.startsWith(tab + "-") || c === tab + "-cloud"
+    )
+  })
+}

--- a/webapp/src/components/config/config-form.tsx
+++ b/webapp/src/components/config/config-form.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { Button } from "@/components/ui/button"
+import { ConfigField } from "@/components/config/field"
+import { saveConfigValues } from "@/app/config/actions"
+import type { ConfigRow } from "@/lib/config"
+
+export interface ConfigFormProps {
+  rows: ConfigRow[]
+}
+
+export function ConfigForm({ rows }: ConfigFormProps) {
+  const [pending, startTransition] = useTransition()
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+
+  return (
+    <form
+      action={(formData: FormData) => {
+        const updates = rows.map((r) => {
+          const type = r.metadata.type ?? "string"
+          const raw =
+            type === "boolean"
+              ? formData.get(r.key) !== null
+              : (formData.get(r.key) ?? "")
+          return { key: r.key, rawValue: raw }
+        })
+        startTransition(async () => {
+          const result = await saveConfigValues(updates)
+          if (result.ok) {
+            setErrors({})
+            setSavedAt(Date.now())
+          } else {
+            setErrors(result.errors ?? {})
+          }
+        })
+      }}
+      className="space-y-6"
+    >
+      {rows.map((r) => (
+        <div key={r.key} className="space-y-1.5">
+          <label className="block text-sm font-mono">{r.key}</label>
+          {r.metadata.description && (
+            <p className="text-xs text-muted-foreground italic whitespace-pre-line">
+              {r.metadata.description}
+            </p>
+          )}
+          <ConfigField
+            name={r.key}
+            type={r.metadata.type ?? "string"}
+            defaultValue={r.value}
+          />
+          {errors[r.key] && (
+            <p className="text-xs text-destructive">{errors[r.key]}</p>
+          )}
+        </div>
+      ))}
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving..." : "Save"}
+        </Button>
+        {savedAt && !pending && Object.keys(errors).length === 0 && (
+          <span className="text-sm text-muted-foreground">Saved</span>
+        )}
+      </div>
+
+      {errors._ && <p className="text-sm text-destructive">{errors._}</p>}
+    </form>
+  )
+}

--- a/webapp/src/components/config/field.tsx
+++ b/webapp/src/components/config/field.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import type { ConfigType } from "@/lib/config"
+
+export interface FieldProps {
+  name: string                  // used as the form field name (= the key)
+  type: ConfigType | string
+  defaultValue: unknown
+}
+
+export function ConfigField({ name, type, defaultValue }: FieldProps) {
+  switch (type) {
+    case "boolean":
+      return (
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            name={name}
+            defaultChecked={Boolean(defaultValue)}
+            className="h-4 w-4"
+          />
+          <span className="text-sm text-muted-foreground">enabled</span>
+        </label>
+      )
+    case "number":
+      return (
+        <Input
+          type="number"
+          name={name}
+          defaultValue={
+            typeof defaultValue === "number" ? String(defaultValue) : ""
+          }
+        />
+      )
+    case "array":
+      return <ArrayEditor name={name} defaultValue={defaultValue} />
+    case "object": {
+      const json = JSON.stringify(defaultValue ?? {}, null, 2)
+      return (
+        <textarea
+          name={name}
+          defaultValue={json}
+          rows={Math.min(15, json.split("\n").length + 1)}
+          className="w-full rounded-md border bg-background p-2 font-mono text-sm"
+        />
+      )
+    }
+    case "string":
+    default: {
+      const val = defaultValue == null ? "" : String(defaultValue)
+      if (val.includes("\n")) {
+        return (
+          <textarea
+            name={name}
+            defaultValue={val}
+            rows={Math.min(10, val.split("\n").length + 1)}
+            className="w-full rounded-md border bg-background p-2 text-sm"
+          />
+        )
+      }
+      return <Input type="text" name={name} defaultValue={val} />
+    }
+  }
+}
+
+interface ArrayEditorProps {
+  name: string
+  defaultValue: unknown
+}
+
+function ArrayEditor({ name, defaultValue }: ArrayEditorProps) {
+  const initial = Array.isArray(defaultValue) ? defaultValue.map(String) : []
+  const [items, setItems] = useState<string[]>(initial)
+
+  return (
+    <div className="space-y-2">
+      {items.map((item, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <Input
+            value={item}
+            onChange={(e) => {
+              const next = [...items]
+              next[idx] = e.target.value
+              setItems(next)
+            }}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setItems(items.filter((_, i) => i !== idx))}
+            aria-label="Remove item"
+          >
+            −
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => setItems([...items, ""])}
+      >
+        + Add item
+      </Button>
+      {/*
+        Hidden field carrying the JSON form value. The Server Action's
+        cast for type=array parses this back via JSON.parse. readOnly
+        because it is controlled-without-handler by design.
+      */}
+      <input type="hidden" name={name} value={JSON.stringify(items)} readOnly />
+    </div>
+  )
+}

--- a/webapp/src/components/config/tabs-nav.tsx
+++ b/webapp/src/components/config/tabs-nav.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link"
+
+export interface TabsNavProps {
+  tabs: string[]
+  active: string
+}
+
+export function TabsNav({ tabs, active }: TabsNavProps) {
+  return (
+    <nav className="border-b mb-6">
+      <ul className="flex gap-1">
+        {tabs.map((t) => {
+          const isActive = t === active
+          return (
+            <li key={t}>
+              <Link
+                href={`/config?tab=${encodeURIComponent(t)}`}
+                className={
+                  "inline-block px-3 py-2 text-sm border-b-2 -mb-[1px] " +
+                  (isActive
+                    ? "border-foreground text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground")
+                }
+              >
+                {t}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/webapp/src/components/nav.tsx
+++ b/webapp/src/components/nav.tsx
@@ -26,6 +26,9 @@ export async function Nav() {
           <Link href="/posts" className="text-sm text-muted-foreground hover:text-foreground">
             Posts
           </Link>
+          <Link href="/config" className="text-sm text-muted-foreground hover:text-foreground">
+            Config
+          </Link>
         </div>
         <div className="flex items-center gap-3">
           <span className="text-sm text-muted-foreground">{session.user.name}</span>

--- a/webapp/src/lib/config.ts
+++ b/webapp/src/lib/config.ts
@@ -1,5 +1,20 @@
 import { sql } from "./db"
 
+export type ConfigType = "string" | "number" | "boolean" | "array" | "object"
+
+export interface ConfigMeta {
+  type?: ConfigType
+  description?: string
+  consumed_by?: string[]
+  default?: unknown
+}
+
+export interface ConfigRow {
+  key: string
+  value: unknown
+  metadata: ConfigMeta
+}
+
 /**
  * Read a value from the `config` table.
  *
@@ -16,4 +31,72 @@ export async function getConfig<T = unknown>(
   }>
   if (rows.length === 0) return defaultValue
   return JSON.parse(rows[0].value) as T
+}
+
+/** List all config rows including their metadata. */
+export async function listConfigsWithMeta(): Promise<ConfigRow[]> {
+  const rows = (await sql`
+    SELECT key, value::text AS value, metadata::text AS metadata
+    FROM config
+    ORDER BY key
+  `) as Array<{ key: string; value: string; metadata: string }>
+  return rows.map((r) => ({
+    key: r.key,
+    value: JSON.parse(r.value),
+    metadata: JSON.parse(r.metadata) as ConfigMeta,
+  }))
+}
+
+/**
+ * Cast a form-submitted value to the JSON shape implied by its declared type.
+ * Throws on conversion failure (e.g. malformed JSON, "abc" for a number).
+ */
+export function castValueByType(raw: unknown, type: string): unknown {
+  switch (type) {
+    case "string":
+      return String(raw)
+    case "number": {
+      const n = Number(raw)
+      if (!Number.isFinite(n)) throw new Error(`Invalid number: ${raw}`)
+      return n
+    }
+    case "boolean":
+      if (typeof raw === "boolean") return raw
+      if (raw === "true") return true
+      if (raw === "false") return false
+      throw new Error(`Invalid boolean: ${raw}`)
+    case "array": {
+      const parsed = typeof raw === "string" ? JSON.parse(raw) : raw
+      if (!Array.isArray(parsed)) throw new Error("Expected JSON array")
+      return parsed
+    }
+    case "object": {
+      const parsed = typeof raw === "string" ? JSON.parse(raw) : raw
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("Expected JSON object")
+      }
+      return parsed
+    }
+    default:
+      return raw
+  }
+}
+
+/**
+ * Update many config values in a single transaction.
+ * Each update's value has already been cast by the caller.
+ */
+export async function setConfigValues(
+  updates: Array<{ key: string; value: unknown }>
+): Promise<void> {
+  if (updates.length === 0) return
+  // Neon serverless driver does not expose explicit transactions; run statements
+  // sequentially. For a single-user tool the loss of atomicity is acceptable.
+  for (const u of updates) {
+    await sql`
+      UPDATE config
+      SET value = ${JSON.stringify(u.value)}::jsonb, updated_at = now()
+      WHERE key = ${u.key}
+    `
+  }
 }


### PR DESCRIPTION
## Summary

- Add a `metadata` jsonb column to the `config` table; ship a YAML catalog
  at `.claude/config-defaults.yaml` listing the params the OSS skill set
  expects.
- Introduce `alt-db config seed`, `set-meta`, `list --with-meta`.
- New keys `daily_plan.cloud.enabled` (default `true`) and
  `daily_plan.cloud.fallback_time` (default `"10:23"`); cloud-scheduler
  honors them as a per-skill gate before dispatching daily-plan-cloud.
- New webapp `/config` page with a `daily-plan` tab and a `Custom` tab,
  driven entirely by `metadata.consumed_by`. Save action does
  per-key validated batch updates.

Design doc: `docs/superpowers/specs/2026-04-29-config-webapp-daily-plan-design.md`.
Closes #21 (Phase 1).

## Follow-ups (filed as separate issues)

- #25 cron reconciler (`*.cloud.fallback_time` → trigger cron sync)
- #26 webapp metadata editor + custom-param UI
- #27 dedicated routines collection editor

## Test plan

- [x] `uv run pytest` (103 passed)
- [x] `cd webapp && npm run test` (30 passed) and `npm run build` (compiles, /config route present)
- [x] Smoke: opened `/config` via `npm run dev`, confirmed each field type renders and saves correctly
- [ ] Smoke: toggle `daily_plan.cloud.enabled`, run cloud-scheduler skill
      directly, confirm daily-plan-cloud is skipped when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)