### PR TITLE
fix(alt-db): make --due-within match task due_date too

### DIFF
--- a/docs/superpowers/specs/2026-05-04-due-within-task-fix-design.md
+++ b/docs/superpowers/specs/2026-05-04-due-within-task-fix-design.md
@@ -1,0 +1,156 @@
+# `--due-within` Fix: Cover task `due_date` Alongside goal `target_date`
+
+Date: 2026-05-04
+
+## Problem
+
+`alt-db entry list --due-within Nd` is documented as a generic deadline filter, but in practice it only matches `goal`-style rows. Tasks with `metadata.due_date` are silently ignored.
+
+Root cause is a single SQL fragment in `src/alt_db/entries.py:66`:
+
+```python
+conditions.append(
+    f"(metadata->>'target_date')::date <= "
+    f"(current_date + make_interval(days => {_next_param(params, due_within_days)}))"
+)
+```
+
+The expression hard-codes `target_date`, but the personal task management spec
+(`docs/superpowers/specs/2026-04-28-personal-task-management-design.md`) and
+`.claude/rules/database-entries.md` define the deadline keys per type:
+
+- `task` → `metadata.due_date`
+- `goal` → `metadata.target_date`
+- `body_measurement_goal` → `metadata.target_date`
+
+The two keys are intentionally different (PM convention: `due_date` is an action-item
+deadline, `target_date` is an aspirational milestone), but the filter does not know
+about the split, so it never sees task deadlines.
+
+## Goals
+
+- Make `--due-within Nd` match rows whose effective deadline (whichever key is set)
+  falls within the window.
+- Keep existing goal-only callers (`daily-plan`, `daily-plan-cloud`) working
+  unchanged.
+- Make the deadline-key duality explicit in code so future filters / queries do not
+  reintroduce the same bug.
+- Add regression tests so any future change that breaks either side is caught.
+
+## Non-Goals
+
+- Schema normalization (collapsing `target_date` and `due_date` into one key). The
+  semantic distinction is real and matches the existing spec; collapsing would
+  require a data migration plus rewriting the spec, the rules doc, and every
+  skill that references either key. Out of scope for a filter bug.
+- Changing how skills consume the filter. `daily-plan` continues to use
+  `--type goal --due-within 7d`; tasks become reachable through the same flag with
+  `--type task` or no `--type`.
+- Adding a separate `--task-due-within` flag. The whole point is one flag for
+  "anything with a deadline coming up."
+
+## Design
+
+### Single deadline expression
+
+Define a module-level constant in `src/alt_db/entries.py` that names the
+effective-deadline column expression once:
+
+```python
+_DEADLINE_EXPR = "COALESCE(metadata->>'due_date', metadata->>'target_date')"
+```
+
+`COALESCE` returns the first non-null argument. `due_date` is checked first so that
+if a row ever ends up with both keys (not currently expected, but possible if a
+future schema lets a goal have both an aspirational and a hard date), the
+task-style "hard deadline" wins, which is the safer interpretation for
+"is this due within N days?".
+
+### Filter rewrite
+
+In `list_entries`, replace the hard-coded fragment with the expression:
+
+```python
+if due_within_days is not None:
+    conditions.append(
+        f"({_DEADLINE_EXPR})::date <= "
+        f"(current_date + make_interval(days => {_next_param(params, due_within_days)}))"
+    )
+    conditions.append(f"{_DEADLINE_EXPR} IS NOT NULL")
+```
+
+The `IS NOT NULL` guard mirrors the existing implementation. It is technically
+redundant given that `NULL <= x` evaluates to `NULL` (filtered out), but is kept
+because (a) it matches existing code's defensive style and (b) it makes the
+"need a deadline to qualify" intent explicit at the SQL level.
+
+### Behaviour matrix
+
+| Caller | Before | After |
+|---|---|---|
+| `--type goal --due-within 7d` (target_date set) | hit | hit (unchanged) |
+| `--type task --due-within 7d` (due_date set) | **missed** | hit |
+| `--due-within 7d` (no `--type`) | only goals | tasks + goals |
+| Row with both keys set | judged by `target_date` | judged by `due_date` (preferred) |
+| Row with neither key | excluded | excluded (unchanged) |
+
+## Testing
+
+Add three tests to `tests/test_entries.py`. They use today's date arithmetic so
+they exercise the actual SQL behaviour rather than the Python wrapper.
+
+1. `test_list_entries_due_within_task_due_date`
+   - Insert a `task` with `metadata.due_date = today + 3 days`.
+   - Assert it appears in `list_entries(due_within_days=7)`.
+   - Asserts the fix.
+
+2. `test_list_entries_due_within_goal_target_date`
+   - Insert a `goal` with `metadata.target_date = today + 3 days`.
+   - Assert it appears in `list_entries(due_within_days=7)`.
+   - Regression guard: ensures the goal path still works.
+
+3. `test_list_entries_due_within_excludes_far_future`
+   - Insert a `task` with `metadata.due_date = today + 30 days`.
+   - Assert it does NOT appear in `list_entries(due_within_days=7)`.
+   - Regression guard: confirms the upper bound still applies.
+
+Use `datetime.date.today() + datetime.timedelta(days=N)` for the dates so the
+tests stay valid across runs. Use the `db` fixture pattern already established
+in the file (`client, entry_ids = db; entry_ids.append(...)`).
+
+## Migrations / Data Changes
+
+None. The change is purely query-side. No existing rows are touched, no schema
+columns added or removed.
+
+## Documentation Updates
+
+`.claude/rules/database-entries.md:215` documents:
+
+```bash
+uv run alt-db entry list --due-within 7d
+```
+
+Post-fix, this command behaves the way the documentation already implies (returns
+all upcoming-deadline entries regardless of type), so no doc edit is needed.
+
+The personal task management design doc and per-skill SKILL.md files reference
+type-specific commands (`--type goal --due-within 7d`) that continue to work
+unchanged.
+
+## Rollout
+
+- Branch: `fix/due-within-task-due-date` from `main`.
+- Single commit (or two: one for the fix, one for tests) with conventional commit
+  prefix `fix(alt-db):`.
+- PR against `main`. No flag, no migration, no coordinated rollout needed.
+
+## Risks
+
+- The `::date` cast still assumes well-formed `YYYY-MM-DD` strings in metadata.
+  Same risk exists today; not addressed here. If a malformed value sneaks in, the
+  whole `list_entries(due_within_days=...)` query errors. Acceptable for now —
+  this is internal data and the schema has been disciplined so far.
+- Anyone currently relying on `--due-within` returning *only* goals (no known
+  consumers do; both call sites already pass `--type goal` explicitly) will see
+  task rows as well. Considered an improvement, not a regression.

--- a/src/alt_db/entries.py
+++ b/src/alt_db/entries.py
@@ -5,6 +5,7 @@ import json
 from .connection import NeonHTTP
 
 _COLUMNS = "id, type, title, content, status, metadata, parent_id, created_at, updated_at"
+_DEADLINE_EXPR = "COALESCE(metadata->>'due_date', metadata->>'target_date')"
 
 
 def _next_param(params: list, value) -> str:
@@ -63,8 +64,11 @@ def list_entries(
     if since_days is not None:
         conditions.append(f"created_at >= now() - make_interval(days => {_next_param(params, since_days)})")
     if due_within_days is not None:
-        conditions.append(f"(metadata->>'target_date')::date <= (current_date + make_interval(days => {_next_param(params, due_within_days)}))")
-        conditions.append("(metadata->>'target_date') IS NOT NULL")
+        conditions.append(
+            f"({_DEADLINE_EXPR})::date <= "
+            f"(current_date + make_interval(days => {_next_param(params, due_within_days)}))"
+        )
+        conditions.append(f"{_DEADLINE_EXPR} IS NOT NULL")
 
     where = " AND ".join(conditions) if conditions else "TRUE"
     result = db.execute(

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -1,5 +1,7 @@
 """Tests for entry operations."""
 
+import datetime as _dt
+
 from alt_db.entries import (
     add_entry,
     delete_entry,
@@ -128,3 +130,18 @@ def test_add_entry_with_parent(db):
     created_ids.append(child_id)
     child = get_entry(client, child_id)
     assert child["parent_id"] == parent_id
+
+
+def test_list_entries_due_within_matches_goal_target_date(db):
+    client, entry_ids = db
+    target = (_dt.date.today() + _dt.timedelta(days=3)).isoformat()
+    entry_id = add_entry(
+        client,
+        type="goal",
+        title="Test: Goal due in 3d",
+        status="active",
+        metadata={"target_date": target},
+    )
+    entry_ids.append(entry_id)
+    results = list_entries(client, due_within_days=7)
+    assert any(r["id"] == entry_id for r in results)

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -159,3 +159,17 @@ def test_list_entries_due_within_matches_task_due_date(db):
     entry_ids.append(entry_id)
     results = list_entries(client, due_within_days=7)
     assert any(r["id"] == entry_id for r in results)
+
+
+def test_list_entries_due_within_excludes_far_future_task(db):
+    client, entry_ids = db
+    far = (_dt.date.today() + _dt.timedelta(days=30)).isoformat()
+    entry_id = add_entry(
+        client,
+        type="task",
+        title="Test: Task due in 30d",
+        metadata={"due_date": far},
+    )
+    entry_ids.append(entry_id)
+    results = list_entries(client, due_within_days=7)
+    assert all(r["id"] != entry_id for r in results)

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -145,3 +145,17 @@ def test_list_entries_due_within_matches_goal_target_date(db):
     entry_ids.append(entry_id)
     results = list_entries(client, due_within_days=7)
     assert any(r["id"] == entry_id for r in results)
+
+
+def test_list_entries_due_within_matches_task_due_date(db):
+    client, entry_ids = db
+    due = (_dt.date.today() + _dt.timedelta(days=3)).isoformat()
+    entry_id = add_entry(
+        client,
+        type="task",
+        title="Test: Task due in 3d",
+        metadata={"due_date": due},
+    )
+    entry_ids.append(entry_id)
+    results = list_entries(client, due_within_days=7)
+    assert any(r["id"] == entry_id for r in results)


### PR DESCRIPTION
## Summary

- The `--due-within Nd` filter on `alt-db entry list` was hard-coded to look at `metadata.target_date`, so `task` rows (whose deadline lives in `metadata.due_date`) were silently excluded — only `goal` rows matched.
- Centralize the deadline expression as a module-level SQL constant `_DEADLINE_EXPR = "COALESCE(metadata->>'due_date', metadata->>'target_date')"` in `src/alt_db/entries.py` and use it in both predicates of the `due_within_days` filter. `due_date` is preferred so task-style hard deadlines win if both keys are ever present.
- Existing goal-only callers (`daily-plan` / `daily-plan-cloud` use `--type goal --due-within 7d`) keep working unchanged — COALESCE falls back to `target_date` when `due_date` is absent.

## Spec

`docs/superpowers/specs/2026-05-04-due-within-task-fix-design.md` (committed in this branch).

## Test plan

- [x] `uv run pytest tests/test_entries.py -v` — 14 / 14 pass, including 3 new tests:
  - `test_list_entries_due_within_matches_goal_target_date` (regression baseline; passed before fix)
  - `test_list_entries_due_within_matches_task_due_date` (failed before fix, passes after)
  - `test_list_entries_due_within_excludes_far_future_task` (upper-bound regression on tasks)
- [x] Local CLI smoke check: `uv run alt-db entry list --type task --due-within 7d` now returns task rows that have `metadata.due_date` set; `--due-within 7d` (no type filter) returns both task and goal rows.

## Out of scope (follow-up)

`webapp/src/lib/queries.ts:getUpcomingDeadlines` has the same `metadata->>'target_date'` hard-coding pattern but is intentionally goal-only (`WHERE type = 'goal'`). Not broken today; only a concern if the webapp ever grows a "show all upcoming deadlines" view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)