### PR TITLE
feat(cloud-scheduler): config-driven cron reconciler

### DIFF
--- a/.claude/config-defaults.yaml
+++ b/.claude/config-defaults.yaml
@@ -37,7 +37,7 @@ params:
     type: boolean
     description: |
       When true, daily-plan-cloud runs as a fallback if you have not
-      already posted a daily plan by daily_plan.cloud.fallback_time.
+      already posted a daily plan by daily_plan.cloud.fallback_hour.
       Set to false to disable the cloud fallback entirely.
     consumed_by: [daily-plan-cloud, cloud-scheduler]
     default: true

--- a/.claude/config-defaults.yaml
+++ b/.claude/config-defaults.yaml
@@ -42,12 +42,28 @@ params:
     consumed_by: [daily-plan-cloud, cloud-scheduler]
     default: true
 
-  daily_plan.cloud.fallback_time:
-    type: string
+  daily_plan.cloud.fallback_hour:
+    type: number
     description: |
-      JST time (HH:MM) at which daily-plan-cloud auto-posts when no daily
-      plan has been posted yet. Cloud-scheduler dispatches based on the
-      hour part. Phase 1: changing this requires the unified trigger cron
-      to already fire on the new hour (cron reconciliation is a follow-up).
-    consumed_by: [daily-plan-cloud, cloud-scheduler]
-    default: "10:23"
+      JST hour (0-23) at which daily-plan-cloud auto-posts when no daily
+      plan has been posted yet. The minute portion is shared across all
+      cloud skills via cloud_scheduler.cron_minute.
+    consumed_by: [daily-plan-cloud, cloud-scheduler, reconcile-cron]
+    default: 10
+
+  cloud_scheduler.cron_minute:
+    type: number
+    description: |
+      Minute slot (0-59) used by the unified cloud-scheduler routine's
+      cron expression. All cloud skills' fire times share this minute;
+      individual skills carry only the hour(s) they need.
+    consumed_by: [cloud-scheduler, reconcile-cron]
+    default: 23
+
+  weekly_plan.reconcile_cron:
+    type: boolean
+    description: |
+      When true, /weekly-plan invokes /reconcile-cron at the end of the
+      session. Set to false to skip the auto-reconcile step.
+    consumed_by: [weekly-plan]
+    default: true

--- a/.claude/skills/cloud-scheduler/SKILL.md
+++ b/.claude/skills/cloud-scheduler/SKILL.md
@@ -58,12 +58,12 @@ the dispatch table:
 **daily-plan-cloud** — read both keys:
 ```bash
 uv run alt-db config get daily_plan.cloud.enabled
-uv run alt-db config get daily_plan.cloud.fallback_time
+uv run alt-db config get daily_plan.cloud.fallback_hour
 ```
 
 If `daily_plan.cloud.enabled` is `false`, skip daily-plan-cloud.
-If the hour part of `daily_plan.cloud.fallback_time` (e.g. `10` from `"10:23"`)
-does not match `<hour>` from Phase 1, skip daily-plan-cloud.
+If `daily_plan.cloud.fallback_hour` (integer 0-23) does not equal `<hour>`
+from Phase 1, skip daily-plan-cloud.
 
 (All other skills retain their existing dispatch-table behaviour for now.
 Per-skill gates for them will be added in subsequent issues.)

--- a/.claude/skills/reconcile-cron/SKILL.md
+++ b/.claude/skills/reconcile-cron/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: reconcile-cron
+description: "Reconcile the unified cloud-scheduler routine's cron with config — computes target hours from *.cloud.fallback_hour and *.cloud.run_hours, shows diff, and updates the routine via /schedule on confirmation"
+---
+
+# Reconcile Cron
+
+Drives the unified cloud-scheduler routine's cron schedule from `config`.
+Computes the target cron, shows the diff against the current routine, and
+on user approval delegates the routine update to the `/schedule` skill.
+
+The reconciler is **update-only**. It does not create routines from scratch
+because that requires choosing the routine's prompt, which is an editorial
+decision outside this skill's scope. If the routine is missing, the skill
+reports it and stops.
+
+## When invoked
+
+### Phase 0: Environment
+
+Install dependencies:
+```bash
+uv sync
+```
+
+### Phase 1: Compute target cron
+
+Read the global cron minute and compute the target cron from time-source
+config rows:
+
+```bash
+MINUTE=$(uv run alt-db config get cloud_scheduler.cron_minute)
+uv run alt-db config list --with-meta --json \
+  | uv run alt-cron compute --cron-minute "$MINUTE"
+```
+
+Parse the JSON output. Capture:
+- `cron` (target cron string, e.g. `"23 10 * * *"`)
+- `hours` (list of hours covered)
+- `minute` (the cron minute)
+
+If `alt-cron compute` exits non-zero, surface the stderr verbatim and end
+the session — do not proceed to Phase 2.
+
+### Phase 2: Read current routine cron
+
+Invoke the `/schedule` skill via the Skill tool with this natural-language
+instruction:
+
+> Use the /schedule skill to list scheduled routines and report the cron
+> expression of the alt cloud-scheduler routine. Reply with the cron
+> string only, or "not found" if no such routine exists.
+
+Capture the returned cron string (or "not found"). If the response is
+ambiguous (multiple matching routines, parse errors), stop and ask the
+user to clean up first.
+
+### Phase 2b: Show diff
+
+Print a short, readable diff:
+
+```text
+Current cloud-scheduler cron:  <current or "not found">
+Target cloud-scheduler cron:   <target>
+Hours covered:                 <comma-separated hours>
+Param sources:
+  <key1> = <value1>
+  <key2> = <value2>
+  ...
+
+Effective fire time(s) JST: HH:MM, HH:MM, ...
+```
+
+Source rows for the "Param sources" section: re-scan the
+`alt-db config list --with-meta --json` output for keys ending in
+`.cloud.fallback_hour` or `.cloud.run_hours`.
+
+If "current" equals "target" (string equality after trimming whitespace),
+print "No change required." and end the session — skip Phase 3 and
+Phase 4.
+
+If "current" was "not found", print:
+"The cloud-scheduler routine does not exist yet. Bootstrap it once via
+/schedule (with a prompt that invokes the cloud-scheduler skill), then
+re-run /reconcile-cron." and end the session.
+
+### Phase 3: Confirm
+
+Ask the user: "Apply this change? (yes/no)". If anything other than an
+affirmative answer, end the session without mutation.
+
+### Phase 4: Delegate the update to /schedule
+
+Invoke the `/schedule` skill via the Skill tool with this instruction:
+
+> Use the /schedule skill to update the alt cloud-scheduler routine's
+> cron expression to `<TARGET>`. Keep its existing prompt unchanged.
+
+Substitute `<TARGET>` with the target cron string from Phase 1.
+
+If `/schedule` reports failure, surface the failure verbatim and end the
+session non-zero.
+
+### Phase 5: Report
+
+After `/schedule` reports completion, print:
+
+```text
+Updated cloud-scheduler routine: <target cron>
+Effective fire time(s) JST: HH:MM, HH:MM, ...
+```
+
+End the session.
+
+## Notes
+
+- The reconciler reads but never writes `cloud_scheduler.cron_minute`
+  itself. To change the global minute, edit it via the webapp or
+  `alt-db config set` and re-run /reconcile-cron.
+- The reconciler does not handle DOW / DOM scheduling; per-skill DOW
+  gates live in `cloud-scheduler`'s Phase 2.5 logic.

--- a/.claude/skills/weekly-plan/SKILL.md
+++ b/.claude/skills/weekly-plan/SKILL.md
@@ -115,3 +115,19 @@ uv run alt-db entry add --type weekly_plan --status posted \
   --title "Weekly Plan <monday YYYY-MM-DD>" \
   --content "<plan_text>"
 ```
+
+### Phase 5: Reconcile cloud-scheduler cron (gated)
+
+Read the gate:
+```bash
+uv run alt-db config get weekly_plan.reconcile_cron
+```
+
+If the value is `false`, skip this phase.
+
+Otherwise invoke the `/reconcile-cron` skill via the Skill tool. The user
+will be present and can confirm the diff if any change is needed.
+
+If `/reconcile-cron` fails, do **not** abort the weekly plan. Surface the
+failure as a one-line warning in the closing summary so the user can
+investigate later.

--- a/docs/superpowers/specs/2026-05-07-cron-reconciler-design.md
+++ b/docs/superpowers/specs/2026-05-07-cron-reconciler-design.md
@@ -1,0 +1,385 @@
+# Cloud-scheduler cron reconciler
+
+Date: 2026-05-07
+Status: Approved
+Tracking: [#25](https://github.com/cloveclovedev/alt/issues/25)
+
+## Goal
+
+Drive the unified cloud-scheduler routine's cron schedule from `config`. When
+the user changes a per-skill schedule param in the webapp (or via CLI), running
+the reconciler updates the routine so the trigger actually fires on the right
+hours. This removes the hand-edited cron line that has lived alongside the
+dispatch table since the unified-trigger consolidation.
+
+The reconciler is a Claude Code slash command. It computes the target cron
+from `config`, presents the diff to the user, and — on approval — delegates the
+routine update to the built-in `/schedule` skill via natural language. No
+direct calls into Cron tools or `/schedule` internals.
+
+The change also tightens the schema for cloud-execution params: each skill's
+schedule param carries hour(s) only; the trigger minute is a single global
+value owned by `cloud_scheduler`.
+
+## Philosophy
+
+- **Single source of truth.** The `config` table decides when the routine fires.
+  Hand-editing the cron line in `/schedule` is no longer the supported path.
+- **Trigger is coarse, dispatcher is fine.** The cron only carries the union of
+  hours across all cloud skills plus the global minute. Day-of-week / day-of-month
+  filtering, "is it actually time to run for this skill" gating, and any
+  fallback-vs-active distinction stay in `cloud-scheduler`'s Phase 2.5 per-skill
+  gate (and in each skill's own logic). The reconciler does not touch DOW/DOM.
+- **No tool guesswork.** Trigger CRUD is delegated to the `/schedule` skill. The
+  reconciler does not try to identify routines by name or prompt content, does
+  not call `CronCreate` / `CronList` / `CronDelete` directly, and does not
+  inspect `/schedule`'s implementation.
+- **Confirmed before applied.** Even though the operation is idempotent, the
+  reconciler shows the diff and waits for user acknowledgment before mutating
+  the routine. Auto-mutation is rejected because deleting a routine drops its
+  prompt; a buggy reconciler run would otherwise be silently destructive.
+
+## Non-goals
+
+- DOW / DOM in the cron expression. If a skill needs to run only on certain
+  days, that's a per-skill gate (separate issue) — the trigger keeps firing
+  daily at the union of hours and the gate exits early on non-matching days.
+- Replacing Phase 2.5 hour gating in `cloud-scheduler`. The dispatcher still
+  reads each skill's schedule param itself; the reconciler only ensures the
+  trigger fires often enough that those gates can ever match.
+- Adding cloud-schedule params for skills other than `daily-plan-cloud`.
+  Migrating the rest (`x-post`, `x-draft`, `nutrition-check`, `wake-check`,
+  `weekly-plan`) is per-skill and tracked separately. After this change the
+  trigger will collapse to firing only at the hours covered by
+  `daily_plan.cloud.fallback_hour`; that is the user-accepted intermediate
+  state until other skills are migrated.
+- Auto-running the reconciler from the webapp. The trigger-management
+  permission surface stays inside Claude Code.
+- Running the reconciler from `weekly-plan-cloud`. The cloud variant runs
+  unattended and the reconciler requires user confirmation, so the auto-step
+  is wired into local `/weekly-plan` only.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  config table                                                    │
+│    cloud_scheduler.cron_minute       (int, 0-59)                 │
+│    daily_plan.cloud.fallback_hour    (int, 0-23)                 │
+│    *.cloud.fallback_hour             (int, 0-23)                 │
+│    *.cloud.run_hours                 (int[], each 0-23)          │
+│    weekly_plan.reconcile_cron        (bool)                      │
+└──────────┬───────────────────────────────────────────────────────┘
+           │  uv run alt-db config list --with-meta --json
+           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  alt-cron compute  (new package: src/alt_cron/)                  │
+│    pure: rows + cron_minute → { hours, minute, cron, warnings }  │
+└──────────┬───────────────────────────────────────────────────────┘
+           │  cron string + diff
+           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  /reconcile-cron skill                                           │
+│    1. compute target                                             │
+│    2. show diff vs intended baseline (see Diff section)          │
+│    3. ask user to confirm                                        │
+│    4. delegate to /schedule via natural-language Skill call      │
+└──────────┬───────────────────────────────────────────────────────┘
+           │  Skill("schedule", "<NL instruction>")
+           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  /schedule skill (Claude Code built-in)                          │
+│    handles routine list / create / update                        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+The reconciler is also reachable as the last step of `/weekly-plan`, gated by
+`weekly_plan.reconcile_cron` (default true). `weekly-plan-cloud` does not call
+it.
+
+## Data model changes
+
+All changes are config-row data updates. No DB schema migration.
+
+### New / renamed params
+
+| Key | Type | Default | Replaces | Consumed by |
+|---|---|---|---|---|
+| `cloud_scheduler.cron_minute` | integer (0-59) | `23` | (new) | `cloud-scheduler`, `reconcile-cron` |
+| `daily_plan.cloud.fallback_hour` | integer (0-23) | `10` | `daily_plan.cloud.fallback_time` (string `"10:23"`) | `daily-plan-cloud`, `cloud-scheduler`, `reconcile-cron` |
+| `weekly_plan.reconcile_cron` | boolean | `true` | (new) | `weekly-plan` |
+
+### Future suffix conventions (no new keys in this change)
+
+| Suffix | Type | Meaning |
+|---|---|---|
+| `*.cloud.fallback_hour` | integer (0-23) | Single fallback hour. Skill runs only if the local equivalent didn't already complete. |
+| `*.cloud.run_hours` | integer[] (each 0-23) | Cloud-only schedule, multiple hours per day. Not a fallback. |
+
+Both suffix shapes contribute hours to the cron union. The reconciler scans
+both and the same hour appearing in either is folded into the union.
+
+The minute portion of any wall-clock time a skill cares about is no longer
+stored in these params — the trigger fires once per hour at
+`cloud_scheduler.cron_minute`.
+
+### Migration steps (data only)
+
+The PR that lands this change executes, in order:
+
+1. Add `cloud_scheduler.cron_minute = 23` (with metadata `type=number`,
+   `consumed_by=[cloud-scheduler, reconcile-cron]`, description).
+2. Add `daily_plan.cloud.fallback_hour = 10` (metadata `type=number`,
+   `consumed_by=[daily-plan-cloud, cloud-scheduler, reconcile-cron]`).
+3. Delete `daily_plan.cloud.fallback_time`.
+4. Add `weekly_plan.reconcile_cron = true` (metadata `type=boolean`,
+   `consumed_by=[weekly-plan]`).
+5. Update `.claude/config-defaults.yaml` to match (so fresh clones seed the
+   new shape).
+
+The migration is performed manually via `uv run alt-db config set`,
+`set-meta`, and `delete` calls in the deployment of this change. It does not
+require new tooling.
+
+## Components
+
+| # | Component | Purpose |
+|---|---|---|
+| 1 | `src/alt_cron/__init__.py`, `cli.py` | New small package. Pure function `compute_target(rows, cron_minute) -> dict` plus thin CLI `alt-cron compute` reading config-list JSON from stdin. |
+| 2 | `pyproject.toml` | Register `alt-cron` entry point and add `src/alt_cron` to packaged sources. |
+| 3 | `tests/test_alt_cron.py` | Pytest coverage for `compute_target`: union of `fallback_hour` + `run_hours`, dedup, sort, type / range validation, empty input error. |
+| 4 | `.claude/skills/reconcile-cron/SKILL.md` | The reconciler slash command. Compute → diff → confirm → delegate to `/schedule`. |
+| 5 | `.claude/skills/cloud-scheduler/SKILL.md` | Phase 2.5 gate updated to read `daily_plan.cloud.fallback_hour` (int) instead of `fallback_time` (string). |
+| 6 | `.claude/skills/daily-plan/SKILL.md` (and `weekly-plan`) | At end of `/weekly-plan`, if `weekly_plan.reconcile_cron` is true, invoke `/reconcile-cron`; warn-only on failure. |
+| 7 | `.claude/config-defaults.yaml` | Replace `daily_plan.cloud.fallback_time` entry; add `cloud_scheduler.cron_minute`, `daily_plan.cloud.fallback_hour`, `weekly_plan.reconcile_cron` entries. |
+| 8 | `webapp/src/components/config/config-form.tsx` (or sibling) | Render an "Effective fire time" hint under any `*.cloud.fallback_hour` / `*.cloud.run_hours` field, computed from the in-form value plus `cloud_scheduler.cron_minute` from the same form load. New `cloud-scheduler` tab is auto-derived from `consumed_by`. |
+| 9 | Manual data migration steps | `alt-db config set/set-meta/delete` calls listed under Migration steps, run as part of the deployment. |
+
+## Compute logic (`alt_cron.compute_target`)
+
+Pure function. Signature:
+
+```python
+def compute_target(rows: list[dict], cron_minute: int) -> dict
+```
+
+`rows` is the JSON list returned by `alt-db config list --with-meta --json`.
+Each row has `key`, `value`, `metadata`.
+
+Return shape:
+
+```json
+{
+  "minute": 23,
+  "hours": [10],
+  "cron": "23 10 * * *",
+  "warnings": []
+}
+```
+
+Algorithm:
+
+1. Validate `cron_minute` is integer `0..59`. Raise on violation.
+2. For each row whose `key` ends in `.cloud.fallback_hour`:
+   - Require `value` is integer `0..23`. Otherwise raise with the offending key.
+   - Add to `hours` set.
+3. For each row whose `key` ends in `.cloud.run_hours`:
+   - Require `value` is a list of integers each `0..23`. Otherwise raise.
+   - Add each element to `hours` set.
+4. If `hours` is empty, raise: "No time-source params found; refusing to
+   produce an empty cron."
+5. Sort hours ascending, dedup.
+6. Build `cron = f"{cron_minute} {','.join(map(str, hours))} * * *"`.
+7. `warnings` is currently always empty. Reserved for future warnings (e.g.,
+   when DOW params are introduced).
+
+The function is pure: no I/O, no time, no environment. The CLI wrapper does
+the I/O.
+
+### CLI
+
+```
+$ uv run alt-db config list --with-meta --json \
+    | uv run alt-cron compute --cron-minute 23
+{"minute": 23, "hours": [10], "cron": "23 10 * * *", "warnings": []}
+```
+
+`--cron-minute` is required; the CLI does not read `config` itself. The
+reconciler skill reads `cloud_scheduler.cron_minute` separately (for the diff
+display) and passes it in.
+
+Errors are written to stderr; exit code is non-zero on any validation failure.
+
+## Reconciler skill flow (`.claude/skills/reconcile-cron/SKILL.md`)
+
+### Phase 0: Environment
+
+```bash
+uv sync
+```
+
+### Phase 1: Read inputs
+
+```bash
+uv run alt-db config get cloud_scheduler.cron_minute
+uv run alt-db config list --with-meta --json | uv run alt-cron compute --cron-minute <minute>
+```
+
+The output JSON gives the target cron string and the hour set.
+
+### Phase 2: Read current routine cron
+
+The skill invokes the `/schedule` skill via the `Skill` tool with a
+natural-language instruction:
+
+> Use the /schedule skill to list scheduled routines and report the cron
+> expression of the alt cloud-scheduler routine. Reply with the cron string
+> only, or "not found" if no such routine exists.
+
+The reconciler captures the returned cron string (or "not found") for the
+diff display. If `/schedule` returns ambiguous output (multiple matching
+routines, parse errors), the reconciler stops with an instruction to the
+user to clean up first.
+
+### Phase 2b: Show diff
+
+The skill prints a short, readable diff:
+
+```
+Current cloud-scheduler cron:  23 0,6,10,12,15,18,19,21 * * *
+Target cloud-scheduler cron:   23 10 * * *
+Hours covered:                 10
+Param sources:
+  daily_plan.cloud.fallback_hour = 10
+
+Effective fire time(s) JST: 10:23
+```
+
+If "current" equals "target", the skill reports "no change" and ends here
+(no Phase 3 / 4).
+
+### Phase 3: Confirm
+
+The skill asks the user to confirm the change before mutating. (The
+no-change case has already been handled at the end of Phase 2b.)
+
+### Phase 4: Delegate to /schedule
+
+On approval, the skill invokes the `/schedule` skill via the `Skill` tool
+with a natural-language instruction:
+
+> Use the /schedule skill to update the alt cloud-scheduler routine to fire
+> on the cron expression `23 10 * * *`. The routine's prompt should remain
+> the existing one that invokes the `cloud-scheduler` skill. If a matching
+> routine doesn't exist, create one with that prompt and cron.
+
+The reconciler does not read or modify `/schedule`'s implementation. It only
+relies on the natural-language interface.
+
+### Phase 5: Report
+
+After `/schedule` reports completion, the reconciler prints:
+- the new cron and effective fire times,
+- a one-line summary (e.g., "Updated cloud-scheduler routine: 23 10 * * *").
+
+If `/schedule` reports failure, the skill surfaces the failure verbatim and
+exits non-zero. No retries.
+
+## /weekly-plan integration
+
+At the end of the existing `/weekly-plan` skill, before its closing summary:
+
+```
+if weekly_plan.reconcile_cron is true:
+    invoke `/reconcile-cron` via the Skill tool
+    on success: include a one-liner in the weekly-plan summary
+    on failure: surface the error in the summary, do not abort the weekly plan
+```
+
+`/weekly-plan-cloud` is unchanged — it does not call the reconciler.
+
+## webapp
+
+The existing generic config form already renders `metadata.type=number` as an
+`<Input type="number">`, so renaming `fallback_time` (string) to
+`fallback_hour` (number) does not require new component code beyond the
+metadata change. Two webapp-only additions:
+
+- **Effective fire time hint.** For any field whose key matches
+  `*.cloud.fallback_hour` or `*.cloud.run_hours`, render a small caption
+  underneath: `Effective fire time(s): HH:MM JST`, where MM is the value of
+  `cloud_scheduler.cron_minute` from the same page load and HH(s) come from
+  the form's current input. The hint updates as the user types. If
+  `cloud_scheduler.cron_minute` is missing, the caption falls back to "MM
+  unset — set cloud_scheduler.cron_minute first".
+- **`cloud-scheduler` tab.** Adding `consumed_by: [cloud-scheduler, ...]` to
+  `cloud_scheduler.cron_minute`'s metadata causes the existing
+  `computeTabs` logic to surface a `cloud-scheduler` tab automatically. To
+  keep Phase 1 scope intentional, `PHASE_1_SKILLS` in
+  `webapp/src/app/config/page.tsx` is extended to include `cloud-scheduler`.
+
+The webapp does not run the reconciler. Editing `fallback_hour` or
+`cron_minute` saves to the DB only; the user is expected to run
+`/reconcile-cron` (or wait for next `/weekly-plan`) to reflect the change in
+the routine.
+
+## Error handling
+
+- **`cloud_scheduler.cron_minute` missing or out of range** — `alt-cron compute`
+  raises with a clear message; reconciler reports the failure and stops before
+  Phase 3.
+- **A `*.cloud.fallback_hour` value is not an int 0..23, or `*.cloud.run_hours`
+  contains an invalid element** — same: `alt-cron compute` raises pointing at
+  the offending key; reconciler stops before Phase 3.
+- **No time-source params found** — `alt-cron compute` raises rather than
+  produce an empty cron. After this change ships there is always at least one
+  (`daily_plan.cloud.fallback_hour`), so this only triggers on misconfigured
+  databases. The reconciler does not delete the existing routine in this case.
+- **`/schedule` reports failure (or it cannot be invoked)** — surface the
+  failure verbatim; exit non-zero. `/weekly-plan` continues but shows the
+  failure in its summary.
+- **User cancels at Phase 3** — exit cleanly, no mutation.
+- **Concurrent edits** — last-write-wins. Two reconciler runs in quick
+  succession would both confirm and apply; the second one is just a no-op
+  diff, which is fine.
+
+## Testing
+
+- **Python (`tests/test_alt_cron.py`)**:
+  - empty `rows` ⇒ raises (no time-source params).
+  - one `*.cloud.fallback_hour=10` ⇒ `cron == "23 10 * * *"`.
+  - one `*.cloud.run_hours=[6,18]` ⇒ `cron == "23 6,18 * * *"`.
+  - mix of `fallback_hour=10` and `run_hours=[6,10,18]` ⇒ hours `[6,10,18]`
+    (dedup), `cron == "23 6,10,18 * * *"`.
+  - hour out of range / non-int ⇒ raises with offending key in message.
+  - `cron_minute` out of range ⇒ raises.
+- **CLI smoke (`tests/test_alt_cron_cli.py` or extend `test_cli.py`)**:
+  - `alt-cron compute --cron-minute 23` reads stdin JSON, prints valid output
+    JSON for a representative input.
+  - Non-zero exit on bad `--cron-minute`.
+- **webapp**:
+  - Manual: `npm run dev` → open `/config`, edit `fallback_hour` → caption
+    updates live with `HH:23`. Switch tab to `cloud-scheduler`, change
+    `cron_minute`, return to `daily-plan` and confirm caption reflects new
+    minute on reload.
+- **Skill (manual smoke after PR review)**:
+  - Run `/reconcile-cron` once with no DB change since last run ⇒ "no change".
+  - Run `/reconcile-cron` after editing `daily_plan.cloud.fallback_hour` to a
+    different hour ⇒ diff shown, confirmation required, `/schedule` updates
+    the routine.
+  - Verify `cloud-scheduler` Phase 2.5 gate keeps working with the new int
+    value (run `/cloud-scheduler` at the configured hour with mocked time).
+
+## Open follow-ups (separate issues)
+
+- Migrate `x-post-cloud`, `x-draft-cloud`, `nutrition-check-cloud`,
+  `wake-check-cloud`, `weekly-plan-cloud` to the new schedule-param model. Each
+  introduces its own `*.cloud.fallback_hour` or `*.cloud.run_hours` and updates
+  the corresponding Phase 2.5 gate in `cloud-scheduler`. Until each migrates,
+  the unified trigger will not fire on hours those skills currently rely on.
+- Per-skill DOW / DOM gates (`*.cloud.*_days_of_week`,
+  `*.cloud.*_day_of_month`) consumed by the dispatcher. Trigger and reconciler
+  remain hour-only.
+- Webapp UX for editing `cloud_scheduler.cron_minute` from the daily-plan tab
+  inline (e.g., a read-only echo with a deep link). Currently it lives in its
+  own `cloud-scheduler` tab.

--- a/docs/superpowers/specs/2026-05-07-cron-reconciler-design.md
+++ b/docs/superpowers/specs/2026-05-07-cron-reconciler-design.md
@@ -268,10 +268,14 @@ no-change case has already been handled at the end of Phase 2b.)
 On approval, the skill invokes the `/schedule` skill via the `Skill` tool
 with a natural-language instruction:
 
-> Use the /schedule skill to update the alt cloud-scheduler routine to fire
-> on the cron expression `23 10 * * *`. The routine's prompt should remain
-> the existing one that invokes the `cloud-scheduler` skill. If a matching
-> routine doesn't exist, create one with that prompt and cron.
+> Use the /schedule skill to update the alt cloud-scheduler routine's cron
+> expression to `23 10 * * *`. Keep its existing prompt unchanged.
+
+The reconciler is update-only. If Phase 2 reported "not found", the
+reconciler exits with a message instructing the user to bootstrap the
+routine via `/schedule` once first; reconciler does not handle the
+create-from-scratch case because that requires choosing the routine's
+prompt, which is an editorial decision outside this skill's scope.
 
 The reconciler does not read or modify `/schedule`'s implementation. It only
 relies on the natural-language interface.
@@ -338,6 +342,9 @@ the routine.
 - **`/schedule` reports failure (or it cannot be invoked)** — surface the
   failure verbatim; exit non-zero. `/weekly-plan` continues but shows the
   failure in its summary.
+- **Routine not found at Phase 2** — reconciler exits with a message asking
+  the user to bootstrap the routine once via `/schedule` (passing a prompt
+  that invokes `cloud-scheduler`). No further action.
 - **User cancels at Phase 3** — exit cleanly, no mutation.
 - **Concurrent edits** — last-write-wins. Two reconciler runs in quick
   succession would both confirm and apply; the second one is just a no-op

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,14 @@ alt-db = "alt_db.cli:main"
 alt-discord = "alt_discord.cli:main"
 alt-body = "alt_body.cli:main"
 alt-home-assistant = "alt_home_assistant.cli:main"
+alt-cron = "alt_cron.cli:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/alt_db", "src/alt_discord", "src/alt_body", "src/alt_home_assistant"]
+packages = ["src/alt_db", "src/alt_discord", "src/alt_body", "src/alt_home_assistant", "src/alt_cron"]
 
 [dependency-groups]
 dev = [

--- a/src/alt_cron/__init__.py
+++ b/src/alt_cron/__init__.py
@@ -1,0 +1,5 @@
+"""Cron computation utilities for the unified cloud-scheduler routine."""
+
+from alt_cron.compute import compute_target
+
+__all__ = ["compute_target"]

--- a/src/alt_cron/cli.py
+++ b/src/alt_cron/cli.py
@@ -1,0 +1,41 @@
+"""CLI entry point for alt-cron."""
+
+import argparse
+import json
+import sys
+
+from alt_cron.compute import compute_target
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="alt-cron",
+        description="Cron computation utilities for cloud-scheduler",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    compute = sub.add_parser(
+        "compute",
+        help="Compute target cron from config rows on stdin",
+    )
+    compute.add_argument(
+        "--cron-minute",
+        type=int,
+        required=True,
+        help="Minute slot for the unified trigger (0-59)",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "compute":
+            rows = json.loads(sys.stdin.read())
+            if not isinstance(rows, list):
+                raise ValueError("stdin JSON must be a list of config rows")
+            result = compute_target(rows, cron_minute=args.cron_minute)
+            print(json.dumps(result))
+    except (ValueError, json.JSONDecodeError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/src/alt_cron/compute.py
+++ b/src/alt_cron/compute.py
@@ -1,0 +1,58 @@
+"""Pure function that derives the unified cron from config rows."""
+
+
+_FALLBACK_HOUR_SUFFIX = ".cloud.fallback_hour"
+_RUN_HOURS_SUFFIX = ".cloud.run_hours"
+
+
+def compute_target(rows: list[dict], cron_minute: int) -> dict:
+    """Compute the target cron expression from time-source config rows.
+
+    Args:
+      rows: output of `alt-db config list --with-meta --json` (list of
+            objects with `key`, `value`, `metadata` fields).
+      cron_minute: integer 0-59, the minute slot used by the unified trigger.
+
+    Returns:
+      {"minute": int, "hours": list[int], "cron": str, "warnings": list[str]}
+
+    Raises:
+      ValueError: on invalid input (bad cron_minute, malformed time-source
+                  values, or empty hour set).
+    """
+    if not isinstance(cron_minute, int) or isinstance(cron_minute, bool):
+        raise ValueError(f"cron_minute must be int, got {type(cron_minute).__name__}")
+    if not 0 <= cron_minute <= 59:
+        raise ValueError(f"cron_minute out of range (0-59): {cron_minute}")
+
+    hours: set[int] = set()
+    for row in rows:
+        key = row.get("key", "")
+        value = row.get("value")
+        if key.endswith(_FALLBACK_HOUR_SUFFIX):
+            hours.add(_validate_hour(key, value))
+        elif key.endswith(_RUN_HOURS_SUFFIX):
+            if not isinstance(value, list):
+                raise ValueError(f"{key}: expected list, got {type(value).__name__}")
+            for item in value:
+                hours.add(_validate_hour(key, item))
+
+    if not hours:
+        raise ValueError("No time-source params found in config rows")
+
+    sorted_hours = sorted(hours)
+    cron = f"{cron_minute} {','.join(str(h) for h in sorted_hours)} * * *"
+    return {
+        "minute": cron_minute,
+        "hours": sorted_hours,
+        "cron": cron,
+        "warnings": [],
+    }
+
+
+def _validate_hour(key: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key}: expected int hour, got {type(value).__name__}")
+    if not 0 <= value <= 23:
+        raise ValueError(f"{key}: hour out of range (0-23): {value}")
+    return value

--- a/tests/test_alt_cron_cli.py
+++ b/tests/test_alt_cron_cli.py
@@ -42,3 +42,11 @@ def test_cli_compute_empty_rows_exits_nonzero():
 def test_cli_compute_malformed_json_exits_nonzero():
     result = _run("not-json", "compute", "--cron-minute", "23")
     assert result.returncode != 0
+
+
+def test_cli_compute_non_list_stdin_exits_nonzero():
+    # Valid JSON but not a list (e.g., an object) — should be rejected by the
+    # CLI's input-shape guard, not by compute_target.
+    result = _run("{}", "compute", "--cron-minute", "23")
+    assert result.returncode != 0
+    assert "must be a list" in result.stderr

--- a/tests/test_alt_cron_cli.py
+++ b/tests/test_alt_cron_cli.py
@@ -1,0 +1,44 @@
+"""Subprocess tests for the alt-cron CLI."""
+
+import json
+import subprocess
+
+
+def _run(stdin: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["uv", "run", "alt-cron", *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_compute_basic():
+    rows = [{"key": "daily_plan.cloud.fallback_hour", "value": 10, "metadata": {}}]
+    result = _run(json.dumps(rows), "compute", "--cron-minute", "23")
+    assert result.returncode == 0, result.stderr
+    parsed = json.loads(result.stdout)
+    assert parsed == {
+        "minute": 23,
+        "hours": [10],
+        "cron": "23 10 * * *",
+        "warnings": [],
+    }
+
+
+def test_cli_compute_invalid_cron_minute_exits_nonzero():
+    rows = [{"key": "x.cloud.fallback_hour", "value": 10, "metadata": {}}]
+    result = _run(json.dumps(rows), "compute", "--cron-minute", "60")
+    assert result.returncode != 0
+    assert "cron_minute" in result.stderr
+
+
+def test_cli_compute_empty_rows_exits_nonzero():
+    result = _run("[]", "compute", "--cron-minute", "23")
+    assert result.returncode != 0
+    assert "No time-source params" in result.stderr
+
+
+def test_cli_compute_malformed_json_exits_nonzero():
+    result = _run("not-json", "compute", "--cron-minute", "23")
+    assert result.returncode != 0

--- a/tests/test_alt_cron_compute.py
+++ b/tests/test_alt_cron_compute.py
@@ -1,0 +1,110 @@
+"""Unit tests for alt_cron.compute_target. Pure function, no DB needed."""
+
+import pytest
+
+from alt_cron import compute_target
+
+
+def test_empty_rows_raises():
+    with pytest.raises(ValueError, match="No time-source params"):
+        compute_target([], cron_minute=23)
+
+
+def test_rows_without_time_sources_raises():
+    rows = [
+        {"key": "plan.discord.channel_id", "value": "12345", "metadata": {}},
+        {"key": "daily_plan.cloud.enabled", "value": True, "metadata": {}},
+    ]
+    with pytest.raises(ValueError, match="No time-source params"):
+        compute_target(rows, cron_minute=23)
+
+
+def test_single_fallback_hour():
+    rows = [
+        {"key": "daily_plan.cloud.fallback_hour", "value": 10, "metadata": {}},
+    ]
+    result = compute_target(rows, cron_minute=23)
+    assert result == {
+        "minute": 23,
+        "hours": [10],
+        "cron": "23 10 * * *",
+        "warnings": [],
+    }
+
+
+def test_two_fallback_hours():
+    rows = [
+        {"key": "daily_plan.cloud.fallback_hour", "value": 10, "metadata": {}},
+        {"key": "weekly_plan.cloud.fallback_hour", "value": 18, "metadata": {}},
+    ]
+    result = compute_target(rows, cron_minute=23)
+    assert result["hours"] == [10, 18]
+    assert result["cron"] == "23 10,18 * * *"
+
+
+def test_run_hours_array():
+    rows = [
+        {"key": "x_post.cloud.run_hours", "value": [0, 6, 18], "metadata": {}},
+    ]
+    result = compute_target(rows, cron_minute=23)
+    assert result["hours"] == [0, 6, 18]
+    assert result["cron"] == "23 0,6,18 * * *"
+
+
+def test_mixed_fallback_and_run_dedup():
+    rows = [
+        {"key": "daily_plan.cloud.fallback_hour", "value": 10, "metadata": {}},
+        {"key": "x_post.cloud.run_hours", "value": [6, 10, 18], "metadata": {}},
+        {"key": "x_draft.cloud.run_hours", "value": [10, 18], "metadata": {}},
+    ]
+    result = compute_target(rows, cron_minute=23)
+    assert result["hours"] == [6, 10, 18]
+    assert result["cron"] == "23 6,10,18 * * *"
+
+
+def test_fallback_hour_out_of_range():
+    rows = [{"key": "x.cloud.fallback_hour", "value": 24, "metadata": {}}]
+    with pytest.raises(ValueError, match="x.cloud.fallback_hour.*out of range"):
+        compute_target(rows, cron_minute=23)
+
+
+def test_fallback_hour_negative():
+    rows = [{"key": "x.cloud.fallback_hour", "value": -1, "metadata": {}}]
+    with pytest.raises(ValueError, match="x.cloud.fallback_hour.*out of range"):
+        compute_target(rows, cron_minute=23)
+
+
+def test_fallback_hour_wrong_type():
+    rows = [{"key": "x.cloud.fallback_hour", "value": "10", "metadata": {}}]
+    with pytest.raises(ValueError, match="x.cloud.fallback_hour.*expected int"):
+        compute_target(rows, cron_minute=23)
+
+
+def test_fallback_hour_bool_rejected():
+    rows = [{"key": "x.cloud.fallback_hour", "value": True, "metadata": {}}]
+    with pytest.raises(ValueError, match="x.cloud.fallback_hour.*expected int"):
+        compute_target(rows, cron_minute=23)
+
+
+def test_run_hours_wrong_type():
+    rows = [{"key": "x.cloud.run_hours", "value": "6,18", "metadata": {}}]
+    with pytest.raises(ValueError, match="x.cloud.run_hours.*expected list"):
+        compute_target(rows, cron_minute=23)
+
+
+def test_run_hours_element_invalid():
+    rows = [{"key": "x.cloud.run_hours", "value": [6, 99], "metadata": {}}]
+    with pytest.raises(ValueError, match="x.cloud.run_hours.*out of range"):
+        compute_target(rows, cron_minute=23)
+
+
+def test_cron_minute_out_of_range():
+    rows = [{"key": "x.cloud.fallback_hour", "value": 10, "metadata": {}}]
+    with pytest.raises(ValueError, match="cron_minute out of range"):
+        compute_target(rows, cron_minute=60)
+
+
+def test_cron_minute_wrong_type():
+    rows = [{"key": "x.cloud.fallback_hour", "value": 10, "metadata": {}}]
+    with pytest.raises(ValueError, match="cron_minute must be int"):
+        compute_target(rows, cron_minute="23")  # type: ignore[arg-type]

--- a/webapp/src/__tests__/config.test.ts
+++ b/webapp/src/__tests__/config.test.ts
@@ -15,6 +15,11 @@ describe("castValueByType", () => {
     expect(() => castValueByType("not-a-number", "number")).toThrow()
   })
 
+  it("throws on empty string for number", () => {
+    expect(() => castValueByType("", "number")).toThrow("Empty number")
+    expect(() => castValueByType("   ", "number")).toThrow("Empty number")
+  })
+
   it("returns true/false for type=boolean", () => {
     expect(castValueByType("true", "boolean")).toBe(true)
     expect(castValueByType("false", "boolean")).toBe(false)

--- a/webapp/src/app/config/page.tsx
+++ b/webapp/src/app/config/page.tsx
@@ -3,7 +3,7 @@ import type { ConfigRow } from "@/lib/config"
 import { ConfigForm } from "@/components/config/config-form"
 import { TabsNav } from "@/components/config/tabs-nav"
 
-const PHASE_1_SKILLS = ["daily-plan"] as const
+const PHASE_1_SKILLS = ["daily-plan", "cloud-scheduler"] as const
 
 interface SearchParams {
   tab?: string

--- a/webapp/src/components/config/config-form.tsx
+++ b/webapp/src/components/config/config-form.tsx
@@ -15,6 +15,13 @@ export function ConfigForm({ rows }: ConfigFormProps) {
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [savedAt, setSavedAt] = useState<number | null>(null)
 
+  const cronMinute = (() => {
+    const row = rows.find((r) => r.key === "cloud_scheduler.cron_minute")
+    if (!row) return null
+    const v = row.value
+    return typeof v === "number" ? v : null
+  })()
+
   return (
     <form
       action={(formData: FormData) => {
@@ -50,6 +57,7 @@ export function ConfigForm({ rows }: ConfigFormProps) {
             name={r.key}
             type={r.metadata.type ?? "string"}
             defaultValue={r.value}
+            cronMinute={cronMinute}
           />
           {errors[r.key] && (
             <p className="text-xs text-destructive">{errors[r.key]}</p>

--- a/webapp/src/components/config/field.tsx
+++ b/webapp/src/components/config/field.tsx
@@ -9,9 +9,10 @@ export interface FieldProps {
   name: string                  // used as the form field name (= the key)
   type: ConfigType | string
   defaultValue: unknown
+  cronMinute?: number | null
 }
 
-export function ConfigField({ name, type, defaultValue }: FieldProps) {
+export function ConfigField({ name, type, defaultValue, cronMinute }: FieldProps) {
   switch (type) {
     case "boolean":
       return (
@@ -25,7 +26,16 @@ export function ConfigField({ name, type, defaultValue }: FieldProps) {
           <span className="text-sm text-muted-foreground">enabled</span>
         </label>
       )
-    case "number":
+    case "number": {
+      if (name.endsWith(".cloud.fallback_hour")) {
+        return (
+          <HourField
+            name={name}
+            defaultValue={defaultValue}
+            cronMinute={cronMinute ?? null}
+          />
+        )
+      }
       return (
         <Input
           type="number"
@@ -35,8 +45,19 @@ export function ConfigField({ name, type, defaultValue }: FieldProps) {
           }
         />
       )
-    case "array":
+    }
+    case "array": {
+      if (name.endsWith(".cloud.run_hours")) {
+        return (
+          <RunHoursField
+            name={name}
+            defaultValue={defaultValue}
+            cronMinute={cronMinute ?? null}
+          />
+        )
+      }
       return <ArrayEditor name={name} defaultValue={defaultValue} />
+    }
     case "object": {
       const json = JSON.stringify(defaultValue ?? {}, null, 2)
       return (
@@ -113,5 +134,121 @@ function ArrayEditor({ name, defaultValue }: ArrayEditorProps) {
       */}
       <input type="hidden" name={name} value={JSON.stringify(items)} readOnly />
     </div>
+  )
+}
+
+interface HourFieldProps {
+  name: string
+  defaultValue: unknown
+  cronMinute: number | null
+}
+
+function HourField({ name, defaultValue, cronMinute }: HourFieldProps) {
+  const initial = typeof defaultValue === "number" ? defaultValue : null
+  const [hour, setHour] = useState<number | null>(initial)
+  return (
+    <div className="space-y-1">
+      <Input
+        type="number"
+        min={0}
+        max={23}
+        name={name}
+        value={hour == null ? "" : String(hour)}
+        onChange={(e) => {
+          const v = e.target.value
+          setHour(v === "" ? null : Number(v))
+        }}
+      />
+      <FireTimeCaption hours={hour == null ? [] : [hour]} cronMinute={cronMinute} />
+    </div>
+  )
+}
+
+interface RunHoursFieldProps {
+  name: string
+  defaultValue: unknown
+  cronMinute: number | null
+}
+
+function RunHoursField({ name, defaultValue, cronMinute }: RunHoursFieldProps) {
+  const initial = Array.isArray(defaultValue)
+    ? defaultValue.filter((x): x is number => typeof x === "number")
+    : []
+  const [hours, setHours] = useState<number[]>(initial)
+  return (
+    <div className="space-y-2">
+      {hours.map((h, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <Input
+            type="number"
+            min={0}
+            max={23}
+            value={String(h)}
+            onChange={(e) => {
+              const v = Number(e.target.value)
+              const next = [...hours]
+              next[idx] = isNaN(v) ? 0 : v
+              setHours(next)
+            }}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setHours(hours.filter((_, i) => i !== idx))}
+            aria-label="Remove hour"
+          >
+            −
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => setHours([...hours, 0])}
+      >
+        + Add hour
+      </Button>
+      <input
+        type="hidden"
+        name={name}
+        value={JSON.stringify(hours)}
+        readOnly
+      />
+      <FireTimeCaption hours={hours} cronMinute={cronMinute} />
+    </div>
+  )
+}
+
+interface FireTimeCaptionProps {
+  hours: number[]
+  cronMinute: number | null
+}
+
+function FireTimeCaption({ hours, cronMinute }: FireTimeCaptionProps) {
+  if (cronMinute == null) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Effective fire time: minute unset — set cloud_scheduler.cron_minute first.
+      </p>
+    )
+  }
+  if (hours.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Effective fire time: (set hour above)
+      </p>
+    )
+  }
+  const sorted = [...new Set(hours)].sort((a, b) => a - b)
+  const mm = String(cronMinute).padStart(2, "0")
+  const list = sorted
+    .map((h) => `${String(h).padStart(2, "0")}:${mm}`)
+    .join(", ")
+  return (
+    <p className="text-xs text-muted-foreground">
+      Effective fire time(s) JST: {list}
+    </p>
   )
 }

--- a/webapp/src/lib/config.ts
+++ b/webapp/src/lib/config.ts
@@ -56,6 +56,9 @@ export function castValueByType(raw: unknown, type: string): unknown {
     case "string":
       return String(raw)
     case "number": {
+      if (typeof raw === "string" && raw.trim() === "") {
+        throw new Error("Empty number")
+      }
       const n = Number(raw)
       if (!Number.isFinite(n)) throw new Error(`Invalid number: ${raw}`)
       return n


### PR DESCRIPTION
## Summary

Drive the unified cloud-scheduler routine's cron schedule from `config`. When a
per-skill cloud schedule param changes (via webapp or CLI), running the new
`/reconcile-cron` slash command recomputes the target cron and — on confirmation
— updates the routine through the built-in `/schedule` skill. This removes the
hand-edited cron line that has lived alongside the dispatch table since the
unified-trigger consolidation.

The schema for cloud-execution params is also tightened: each skill's schedule
param carries hour(s) only; the trigger minute is a single global value owned by
`cloud_scheduler.cron_minute`.

Closes #25.

## What changed

- **`alt-cron` package** (`src/alt_cron/`) — pure `compute_target(rows, cron_minute)`
  that folds every `*.cloud.fallback_hour` and `*.cloud.run_hours` into the cron
  hour union, plus a thin `alt-cron compute` CLI reading config-list JSON from stdin.
- **`/reconcile-cron` skill** — compute target → diff vs current routine cron →
  confirm → delegate the update to `/schedule` via natural language. Update-only;
  no direct Cron* calls, no `/schedule` internals.
- **`cloud-scheduler` Phase 2.5 gate** — reads `daily_plan.cloud.fallback_hour`
  (int) instead of `fallback_time` (string).
- **`/weekly-plan`** — invokes `/reconcile-cron` at the end, gated by
  `weekly_plan.reconcile_cron` (default true); warn-only on failure.
  `weekly-plan-cloud` is unchanged.
- **config schema** — new `cloud_scheduler.cron_minute` (number),
  `daily_plan.cloud.fallback_hour` (number), `weekly_plan.reconcile_cron`
  (boolean); `config-defaults.yaml` updated for fresh clones.
- **webapp** — renders an "Effective fire time" hint under
  `*.cloud.fallback_hour` / `*.cloud.run_hours` fields, rejects empty-string for
  number fields, and surfaces a `cloud-scheduler` tab.

## Data migration

Performed manually against the live DB as part of this change (additive,
pre-merge): `cloud_scheduler.cron_minute=23`, `daily_plan.cloud.fallback_hour=10`,
`weekly_plan.reconcile_cron=true` are inserted with metadata. The old
`daily_plan.cloud.fallback_time` string key is retained for rollback and deleted
only after merge.

## Intermediate state

Until the other cloud skills (`x-post`, `x-draft`, `nutrition-check`,
`wake-check`, `weekly-plan`) migrate to the new schedule-param shape, the unified
trigger collapses to firing only at hours covered by
`daily_plan.cloud.fallback_hour` (`23 10 * * *`). This is the accepted
intermediate state; per-skill migration is tracked separately.

## Testing

- `uv run pytest -q` → 125 passed (includes `compute_target` unit coverage and
  `alt-cron compute` CLI smoke).
- `alt-cron compute --cron-minute 23` over live config → `{"cron": "23 10 * * *"}`.

See the design spec at `docs/superpowers/specs/2026-05-07-cron-reconciler-design.md`.
