### PR TITLE
feat(training): add training tracking (workout logging + daily/weekly review)

### DIFF
--- a/.claude/rules/database-entries.md
+++ b/.claude/rules/database-entries.md
@@ -13,6 +13,7 @@ Use `uv run alt-db entry` to manage entries in Neon Postgres (the second brain s
 | `tech_interest` | Technologies to explore or evaluate |
 | `business` | Business-related decisions and plans |
 | `routine_event` | Routine completion / baseline records |
+| `workout_log` | Logged training sessions (adherence + performance) |
 | `body_measurement` | Body composition snapshots (e.g., InBody) |
 | `body_measurement_goal` | Body composition target settings |
 | `nutrition_item` | Food items registry (calorie/protein per item) |
@@ -98,6 +99,16 @@ Each section follows the same shape:
 - Title: routine name; must match a key in `config.routines` (the routines skill matches completion records to definitions by title)
 - Lifecycle: created when a routine is performed (`completed`) or when establishing a starting point for a new routine (`baseline`)
 - Consumers: routines skill (overdue/due-soon calculation), daily-plan (overdue routines), weekly-plan (week's routines)
+
+### workout_log
+
+- Status: not used
+- Metadata: { logged_date: "YYYY-MM-DD", place: "personal|gym_24h|home_elevator|floor1|basketball|other", workout_type: "upper|lower|full|hiit|basketball|other", exercises: [{ name: string, weight_kg?: number, reps?: number, sets?: number, value?: number, unit?: string, note?: string }], rpe?: number, note?: string, source_message_ids: string[], estimated_by: "discord_parse" }
+- Content: raw Discord message text (provenance)
+- Parent: not used
+- Title: `Workout YYYY-MM-DD — <place label>`
+- Lifecycle: created by the training skill from posts in the training Discord channel; one entry per workout, with multiple posts for the same logged_date + place merged into one entry; idempotent via metadata.source_message_ids
+- Consumers: training skill (today/review), daily-plan (today's workout), weekly-plan (training review)
 
 ### body_measurement
 

--- a/.claude/skills/daily-plan/SKILL.md
+++ b/.claude/skills/daily-plan/SKILL.md
@@ -51,6 +51,9 @@ Run these commands in parallel to collect today's context:
    ```
    These are personal tasks tracked in the entries table (separate from GitHub issues). Sort active by priority (P0→P3, then unprioritized) then by `metadata.due_date` (earliest first, no-due last). Backlog is used for duplicate detection during the Phase 3 promotion flow.
 
+7. **Training:**
+   Run the `training` skill logic — first `parse` (ingest new workout posts from the training channel into `workout_log`), then `today` (today's planned workout, the week-so-far adherence counter, and last numbers for today's key lifts). If `config.training.discord.channel_id` is empty, skip parse and still show today's planned workout from `config.training.plan`.
+
 ### Phase 2: Present Summary
 
 Present all gathered information organized as:
@@ -70,6 +73,11 @@ Select up to 5 recommended issues based on priority (P0/P1 first), milestone urg
   - Sub-task: Title
 - [P2] Title
 - ...
+
+## Training
+- Today's workout: [place] — [menu] (or "rest day")
+- This week so far: Personal n/1, 24h gym n/2
+- Last numbers: [key lift]: [weight]kg [reps]x[sets]
 
 ## Routines Due
 - Overdue: ...
@@ -118,12 +126,14 @@ Based on the Phase 3 discussion outcome, generate a concise channel summary:
 📅 Notable calendar event HH:MM
 ✅ Routine item
 📌 Task title — due today (P1)
+🏋 Today's workout — [place/menu]
 ```
 
 - **🔧** Issues decided to work on today
 - **📅** Calendar events requiring action or attention
 - **✅** Routines to handle today
 - **📌** Notable tasks: status=active AND (due_date<=today OR priority in [P0,P1]). Cap at 2-3 lines; remaining active tasks live in the thread detail.
+- **🏋** Today's planned workout (omit on rest days)
 - One item per line, icon repeated per item
 - Omit categories with no items
 - Blank line between title and items

--- a/.claude/skills/training/SKILL.md
+++ b/.claude/skills/training/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: training
+description: Use to log workouts from the training Discord channel, see today's planned workout, or review weekly training adherence and progression
+---
+
+# Training
+
+Tracks training: parses workout posts from a dedicated Discord channel into
+`workout_log` entries, surfaces today's planned workout, and reviews weekly
+adherence and key-lift progression. Invoked directly (`/training`) and by
+`daily-plan` / `weekly-plan`.
+
+## Terminology
+
+- **training** — the program/domain.
+- **workout** — one session; one `workout_log` entry, which may be assembled from
+  several Discord posts.
+
+## Configuration
+
+Read the master plan and settings:
+```bash
+uv run alt-db config get training
+```
+Fields:
+- `plan` — markdown master plan (canonical: places, weekday→menu, irregularity
+  algorithm, safety notes).
+- `key_lifts` — exercise identifiers tracked for progression.
+- `kpi` — performance KPIs measured occasionally (e.g., vertical jump).
+- `weekly_base` — `{ personal, gym_24h_min, gym_24h_target }` adherence rule.
+- `discord.channel_id` — dedicated training channel. If empty, `parse` is a no-op
+  (tell the caller the channel is not configured yet).
+
+## Modes
+
+Pick what the caller needs: `parse`, `today`, or `review`. The default for a bare
+`/training` invocation is: run `parse`, then `today`.
+
+### Mode: parse — ingest workout posts into `workout_log`
+
+1. Current time in JST: `TZ=Asia/Tokyo date '+%Y-%m-%dT%H:%M:%S+09:00'`. Compute
+   `<window_start>` = 7 days before now, ISO 8601.
+2. If `discord.channel_id` is empty, stop and report "training channel not
+   configured."
+3. Read recent messages:
+   ```bash
+   uv run alt-discord read <channel_id> --after <window_start>
+   ```
+   (Equivalently `alt_discord.reader.fetch_messages('<channel_id>', after_timestamp='<window_start>')`.)
+4. Drop messages where `author.bot == true`.
+5. Build the processed-id set: list recent workout logs and collect every
+   `metadata.source_message_ids`:
+   ```bash
+   uv run alt-db --json entry list --type workout_log --since 10d
+   ```
+   Skip any message whose id is already in that set.
+6. For each remaining message, normalize with the LLM into:
+   - `logged_date` — from the message timestamp in JST (unless the post states a
+     date).
+   - `place` — `personal | gym_24h | home_elevator | floor1 | basketball | other`.
+   - `workout_type` — `upper | lower | full | hiit | basketball | other`.
+   - `exercises[]` — `{ name, weight_kg?, reps?, sets?, value?, unit?, note? }`.
+     Use `weight_kg`/`reps`/`sets` for resistance work; `value`/`unit` for
+     measurements (e.g., a vertical-jump test `value:60, unit:"cm"`) and HIIT
+     (rounds/duration).
+   - `rpe?`, `note?`.
+   Use the master `plan` to disambiguate `place`/`workout_type` and expected
+   exercise names. Write all values in English.
+7. Merge or create (preserves the one-entry-per-workout invariant):
+   - If an existing `workout_log` already has the same `logged_date` AND `place`,
+     append the new exercises to its `metadata.exercises` and add this message id
+     to `metadata.source_message_ids`:
+     ```bash
+     uv run alt-db entry update <id> --metadata '<full merged metadata json>'
+     ```
+   - Otherwise create a new entry:
+     ```bash
+     uv run alt-db entry add --type workout_log \
+       --title "Workout <logged_date> — <place label>" \
+       --content "<raw message text>" \
+       --metadata '{"logged_date":"<logged_date>","place":"<place>","workout_type":"<type>","exercises":[...],"source_message_ids":["<message_id>"],"estimated_by":"discord_parse"}'
+     ```
+8. (Optional) Post a one-line confirmation to the channel:
+   ```bash
+   uv run alt-discord post <channel_id> "🏋 logged: <short summary>"
+   ```
+
+### Mode: today — today's planned workout
+
+1. Date and weekday in JST.
+2. From `config.training.plan`, read this weekday's planned workout (place +
+   menu).
+3. Reconcile with today's calendar `FIT |` events and the irregularity algorithm
+   in `plan`:
+   - Sunday becomes basketball → Saturday slides to full rest.
+   - Basketball on Wed/Thu → that day's gym/home work is paused; basketball is the
+     workout.
+   - High fatigue → optional home/floor work may be skipped; the week is OK if the
+     base is met.
+4. For each key lift in today's menu, fetch the last recorded numbers:
+   ```bash
+   uv run alt-db --json entry list --type workout_log --since 60d
+   ```
+   For each key lift, find the most recent `exercises[]` item whose `name` matches
+   and show its `weight_kg`×`reps`×`sets` as "last time."
+5. Compute this week's adherence so far (see `review` step 3) for the one-line
+   "this week so far" counter.
+6. Output:
+   ```
+   ### Today's Workout (<weekday>)
+   <place> — <menu>
+   - <exercise>: last <weight>kg <reps>x<sets>
+   This week so far: Personal <n>/<base>, 24h gym <n>/<target>
+   ```
+   If today is a rest day (or a slide applies), say so explicitly.
+
+### Mode: review — weekly adherence + progression
+
+1. Compute `<monday>`..`<sunday>` for the current week (JST).
+2. Fetch this week's workouts:
+   ```bash
+   uv run alt-db --json entry list --type workout_log --since 8d
+   ```
+   Keep entries whose `metadata.logged_date` falls in the week.
+3. Adherence: count workouts grouped by `place` (personal, gym_24h, ...). Compare
+   to `weekly_base` (`personal`, `gym_24h_min`/`gym_24h_target`). Report per-day
+   hit/miss and whether the base was met. Count a basketball workout as
+   max-intensity per the irregularity algorithm.
+4. Progression: for each `key_lift` and `kpi`, list the recent trend across
+   `workout_log` entries (last few data points; e.g., deadlift 60 → 62.5 kg;
+   vertical jump latest vs previous). Pull from a wider window if needed:
+   ```bash
+   uv run alt-db --json entry list --type workout_log --since 60d
+   ```
+5. Output:
+   ```
+   ### Training Review (Week of <monday>)
+   Adherence: Personal <n>/<base> · 24h gym <n>/<target> · base <met / not met>
+   - Mon <hit/miss>: <summary> ...
+   Progression:
+   - deadlift: 60 → 62.5 kg
+   - vertical jump: 60 cm (prev 58)
+   ```
+
+## Notes
+
+- All `workout_log` content and metadata written in English.
+- `workout_log` needs no schema migration — the `entries.type` column is an open
+  string.
+- Idempotency is by `metadata.source_message_ids`, so re-reading an overlapping
+  window is safe.

--- a/.claude/skills/weekly-plan/SKILL.md
+++ b/.claude/skills/weekly-plan/SKILL.md
@@ -47,6 +47,9 @@ Use this date to compute `<monday>` (start of current week) and `<next-monday>` 
    ```
    Sort active by priority (P0→P3, then unprioritized) then `metadata.due_date`. Sort backlog by created_at (oldest first — they have been waiting longest).
 
+7. **Training:**
+   Run the `training` skill `review` mode to get this week's adherence (workouts by place vs `config.training.weekly_base`, per-day hit/miss) and key-lift / KPI progression.
+
 ### Phase 2: Present Week Overview
 
 ```
@@ -76,6 +79,12 @@ Use this date to compute `<monday>` (start of current week) and `<next-monday>` 
 - Mon: Wash sheets, Clean toilet
 - Wed: ...
 - Sat: ...
+
+### Training Review
+- Adherence: Personal n/1 · 24h gym n/2 · base met/not met
+- Per-day: Mon hit/miss, Tue ..., ...
+- Progression: deadlift 60→62.5kg; vertical jump latest vs prev
+- Next week's menu by day (from config.training, reconciled with the calendar)
 
 ### Goals Overview
 - Active goals with current status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Personal planning and knowledge hub powered by Claude Code skills.
 - `/daily-plan` — Run daily planning workflow
 - `/weekly-plan` — Run weekly planning workflow
 - `/routines` — Check and manage routines
+- `/training` — Log workouts, see today's workout, review weekly training
 
 ## External Tools
 
@@ -24,3 +25,4 @@ Personal planning and knowledge hub powered by Claude Code skills.
 
 Manage Discord channel IDs, GitHub repos, calendar settings via `uv run alt-db config set/get`.
 Routine definitions are managed via `uv run alt-db config get/set routines` (single JSON object keyed by routine title).
+Training master plan (places, weekday menus, irregularity rules) and settings are managed via `uv run alt-db config get/set training`. Workouts are logged via the training Discord channel and stored as `workout_log` entries.

--- a/docs/superpowers/specs/2026-06-21-training-tracking-design.md
+++ b/docs/superpowers/specs/2026-06-21-training-tracking-design.md
@@ -1,0 +1,220 @@
+# Training Tracking — Design
+
+- Date: 2026-06-21
+- Status: Approved (design)
+
+## Summary
+
+alt currently represents training only as recurring Google Calendar `FIT |`
+events. Those events are schedule-only: there is no record of whether a session
+was actually done, nor of performance progression (working weights, reps, or the
+vertical-jump KPI). This document designs a training-tracking subsystem so that
+`daily-plan` and `weekly-plan` can review both adherence and progression.
+
+Workouts are logged through a dedicated Discord channel and parsed into
+structured entries, mirroring the existing nutrition-logging pattern
+(`nutrition-check-cloud`). Review is **pull-first**: no new scheduled cloud
+infrastructure is introduced. A push variant (reminders, missing-log detection,
+weekly auto-summary) is explicitly deferred.
+
+This addresses the long-standing gap tracked by alt#6 ("feat: add exercise
+tracking system").
+
+### Goals
+
+- Track **adherence** (was the weekly base met) and **performance** (key-lift
+  numbers and KPI measurements).
+- Log workouts via a dedicated Discord channel, parsed into structured entries.
+- Surface "today's menu" plus recent numbers in `daily-plan`; surface weekly
+  adherence plus progression in `weekly-plan`.
+- Reuse existing patterns: the entries table, the `routines` skill structure,
+  and the Discord read/parse flow.
+
+### Non-goals (deferred)
+
+- A cloud push skill (`workout-check-cloud`): reminders, missing-log detection,
+  weekly auto-summary.
+- Webapp progression charts (could later ride on the existing body dashboard).
+- Automatic per-exercise 1RM estimation.
+
+## Terminology
+
+To keep usage consistent across the skill, config, entry type, and docs:
+
+- **training** — the domain / program / feature: the ongoing practice and its
+  master plan. Used for the skill (`training`), the config key
+  (`config.training`), and the review concepts ("training plan", "Training
+  Review").
+- **workout** — a single training session: one logged activity (one gym visit,
+  one HIIT session, one basketball game). This is the unit of record — one
+  `workout_log` entry per workout. A workout may be assembled from one or more
+  Discord posts (e.g., one post per exercise), which the parser merges into a
+  single entry. "Today's workout" is the session planned for today; its **menu**
+  is that workout's list of exercises.
+
+## Data Model
+
+### `config.training` (master data)
+
+A single config key (`training`) holding a JSON object. The canonical content is
+a markdown string; a small set of machine-readable fields drive deterministic
+logic. Managed via `uv run alt-db config get/set training` (same flow as
+`routines`).
+
+| Field | Type | Purpose |
+|---|---|---|
+| `plan` | string (markdown) | Canonical master plan: purpose, places, weekday→menu mapping, irregularity algorithm, safety/etiquette notes. Free-form; the user appends rules here over time. |
+| `key_lifts` | string[] | Stable exercise identifiers used to drive progression review. |
+| `kpi` | string[] | Performance KPIs measured occasionally (e.g., vertical jump). |
+| `weekly_base` | object | Adherence rule as counts, e.g. `{ "personal": 1, "gym_24h_min": 1, "gym_24h_target": 2 }`. |
+| `discord.channel_id` | string | Dedicated training channel used for logging. |
+
+**Canonicality.** `plan` (prose) is authoritative. The structured fields are
+hints derived from the plan; if they diverge, the prose wins and both should be
+updated. All consumers are LLM-driven skills, so they read the prose directly —
+no rigid schema is required for the weekday→menu mapping or the irregularity
+rules.
+
+**Why config (not a knowledge entry).** This is behavior-driving reference data
+for skills (a peer of `routines` and the calendar context), not a reviewable
+knowledge memo. Keeping it in config avoids polluting the `weekly-plan` "recent
+entries" and webapp `/entries` feeds, and it slots into the per-skill config
+webapp UI roadmap.
+
+### `workout_log` entry type
+
+A new entry `type` by convention only. The entries table `type` column is an open
+string (see `src/alt_db/entries.py`), so **no schema migration is required** —
+this matches how `routine_event`, `nutrition_log`, etc. were introduced.
+
+One entry per workout (one training session).
+
+- `type`: `workout_log`
+- `title`: human-readable, date-stamped workout label — e.g.
+  `Workout YYYY-MM-DD — 24h Gym Lower`.
+- `status`: not used.
+- `content`: raw Discord message text (provenance / re-parse source).
+- `metadata`:
+  - `logged_date` (`YYYY-MM-DD`) — workout date, derived from the message
+    timestamp in JST unless the post states otherwise.
+  - `place` — one of `personal | gym_24h | home_elevator | floor1 | basketball | other`.
+  - `workout_type` — one of `upper | lower | full | hiit | basketball | other`.
+  - `exercises` (array) — each item `{ name, weight_kg?, reps?, sets?, value?, unit?, note? }`.
+    `weight_kg`/`reps`/`sets` cover resistance work; `value`/`unit` cover
+    measurements (e.g., a vertical-jump test of 60 cm) and HIIT
+    (rounds/duration). This keeps measurements and HIIT in the same structure
+    without introducing additional entry types.
+  - `rpe` (number, optional) — overall workout intensity.
+  - `note` (string, optional).
+  - `source_message_ids` (string[]) — Discord message ids that contributed to
+    this workout, used for idempotency. A workout assembled from several posts
+    carries all of their ids.
+  - `estimated_by` — `discord_parse` (provenance; reserved for future modes).
+- `parent`: not used.
+
+**Idempotency & multi-post workouts.** Before processing a message, the parser
+runs `entry search "<message_id>"` and skips it if any `workout_log` already
+lists that id in `source_message_ids`. When a new message belongs to an existing
+workout for the same `logged_date` + `place` (e.g., a follow-up post adding more
+exercises), the parser appends its exercises to that entry and adds the message
+id to `source_message_ids`, rather than creating a second workout. Otherwise it
+creates a new `workout_log`. The rare two-workouts-same-place-same-day case is
+disambiguated by a note in the post (e.g., "pm"). This preserves the invariant:
+one `workout_log` entry = one workout, so adherence can count entries directly.
+
+## The `training` skill
+
+A standalone skill, a peer of `routines`. It is invoked directly (`/training`)
+and by `daily-plan` / `weekly-plan` — mirroring how those skills already "run the
+routines skill logic." It has three responsibilities:
+
+1. **parse** — read recent messages from the training channel over a bounded
+   window (e.g., the last 7 days, via
+   `uv run alt-discord read <channel_id> --after <iso8601>`, or
+   `alt_discord.reader.fetch_messages`), skip bot messages and messages already
+   processed (their id present in some `workout_log`'s `source_message_ids`), and
+   LLM-normalize each remaining message — appending its exercises to the matching
+   workout for the same `logged_date` + `place` if one exists, otherwise creating
+   a new `workout_log`. No stored cursor is needed; idempotency comes from
+   `source_message_ids` dedupe, so re-reading an overlapping window is safe. An
+   optional confirmation reply may be posted to the channel.
+2. **today** — reconcile `config.training.plan` + today's weekday + today's
+   calendar `FIT |` events + the irregularity algorithm to produce **today's
+   workout** (its menu of exercises). Surface the last recorded numbers for that
+   workout's key lifts so the user knows the targets to beat.
+3. **review** — compute the current week's adherence against `weekly_base`
+   (workouts grouped by place/type, with per-day hit/miss) and the progression of
+   `key_lifts` / `kpi` over recent `workout_log` entries.
+
+Keeping this logic in one skill isolates training concerns, keeps
+`daily-plan` / `weekly-plan` thin, and follows the `routines` precedent.
+
+### Irregularity algorithm
+
+Encoded as prose in `config.training.plan`; applied by **today** and **review**:
+
+- Sunday becomes basketball → slide Saturday to full rest.
+- Basketball lands on Wednesday/Thursday → that day's gym/home training is
+  paused; basketball counts as a max-intensity workout.
+- Fatigue is high → skip optional home/floor work; the week is considered OK as
+  long as the base (personal ×1 + 24h gym ×1–2) is met.
+
+## Skill Integration
+
+### `daily-plan`
+
+- Phase 1 (gather): run `training` **parse** (so the day's view reflects last
+  night's posts), then `training` **today**.
+- Phase 2 (present): a new "Training" section — today's workout (menu);
+  week-so-far vs base (e.g., Personal 1/1, 24h gym 1/2); last numbers for that
+  workout's key lifts.
+- Phase 4 (Discord summary): an optional 🏋 line for today's workout.
+
+### `weekly-plan`
+
+- A new "Training Review" section — adherence vs `weekly_base` (per-day
+  hit/miss, base met?); progression of key lifts and KPI (e.g., deadlift
+  60→62.5 kg; vertical jump latest vs previous); irregularity notes (basketball
+  as max intensity); and next week's weekday menus reconciled with the calendar.
+
+## Discord Logging UX
+
+- A dedicated training channel; its id is stored in
+  `config.training.discord.channel_id`. The user creates the channel and provides
+  the id.
+- One or more free-form posts per workout (e.g., one post per exercise is fine;
+  the parser merges them by `logged_date` + `place`). The suggested format is
+  loose and parsed flexibly by the LLM. Illustrative example:
+
+  ```
+  thu 24h gym lower
+  bulgarian 20kg 10x3
+  single-leg calf bodyweight 15x3
+  vertical jump 60cm
+  rpe8 left ankle tight
+  ```
+
+## Documentation Updates
+
+- `.claude/rules/database-entries.md` — add the `workout_log` type to the
+  overview table and the per-type reference section.
+- `CLAUDE.md` — note `config.training` and the `/training` skill under
+  configuration / key commands.
+
+## Components Summary
+
+| Component | New/Changed | Notes |
+|---|---|---|
+| `config.training` | new config key | markdown plan + machine hints |
+| `workout_log` entry type | new convention | no migration (open `type` column) |
+| `training` skill | new skill | parse / today / review; peer of `routines` |
+| `daily-plan` skill | changed | add Training section + parse call |
+| `weekly-plan` skill | changed | add Training Review section |
+| `database-entries.md`, `CLAUDE.md` | changed | document the new type and config |
+
+## Out of Scope (future, explicitly deferred)
+
+- `workout-check-cloud` (push: reminders, missing-log detection, weekly
+  auto-summary).
+- Webapp progression charts.
+- Automatic per-exercise 1RM estimation.


### PR DESCRIPTION
## Summary

Adds a training-tracking subsystem so daily-plan and weekly-plan can review training adherence and progression, with workouts logged through a dedicated Discord channel (mirroring the nutrition-logging pattern). Addresses #6.

## What's included

- **`workout_log` entry type** — convention only, no migration (`entries.type` is an open string). Documented in `.claude/rules/database-entries.md`.
- **`config.training`** master data (master plan markdown + `key_lifts` / `kpi` / `weekly_base` / `discord.channel_id`). Seeded in the DB, not committed.
- **`training` skill** (peer of `routines`), three modes:
  - `parse` — Discord posts → `workout_log`; multiple posts for the same date+place merge into one entry; idempotent via `source_message_ids`.
  - `today` — today's planned workout (from `config.training.plan` + calendar + irregularity rules) plus last recorded numbers.
  - `review` — weekly adherence vs `weekly_base` and key-lift / KPI progression.
- **daily-plan** — runs parse+today; adds a Training section and an optional summary line.
- **weekly-plan** — runs review; adds a Training Review section.
- **CLAUDE.md** — documents `/training` and `config.training`.

## Design

See `docs/superpowers/specs/2026-06-21-training-tracking-design.md`.

## Deferred (out of scope)

- Cloud variants (`daily-plan-cloud` / `weekly-plan-cloud`) parse/review integration — parsing currently happens when you run `/daily-plan`, `/weekly-plan`, or `/training`.
- `workout-check-cloud` push skill, webapp progression charts, per-exercise 1RM estimation.

## Follow-up to activate

Create a dedicated training Discord channel and set `config.training.discord.channel_id`; `parse` is a no-op until then.

## Verification

- No new Python. Existing suite: `127 passed`.
- Live round-trip smoke test of the `workout_log` convention passed; `config.training` round-trip verified.
- Final whole-branch review: ready to merge, no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)